### PR TITLE
Maintenance/comscore ios usagepropertiesautoupdatemode

### DIFF
--- a/comscore/ios/THEOplayerComscoreRCTComscoreAPI.swift
+++ b/comscore/ios/THEOplayerComscoreRCTComscoreAPI.swift
@@ -31,6 +31,7 @@ class THEOplayerComscoreRCTComscoreAPI: NSObject, RCTBridgeModule {
                     publisherId: ComscoreConfig["publisherId"] as! String,
                     applicationName: ComscoreConfig["applicationName"] as! String,
                     userConsent: self.mapUserConsent(userConsent: ComscoreConfig["userConsent"] as! String),
+                    usagePropertiesAutoUpdateMode: self.mapUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode: ComscoreConfig["usagePropertiesAutoUpdateMode"] as? String ?? "foregroundOnly"),
                     adIdProcessor: nil,
                     debug: ComscoreConfig["debug"] as! Bool
                 )
@@ -140,6 +141,19 @@ class THEOplayerComscoreRCTComscoreAPI: NSObject, RCTBridgeModule {
             customLabels: metadata["customLabels"] as? [String:String]
         )
         return comscoreMetadata
+    }
+    
+    func mapUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode: String) -> ComscoreUsagePropertiesAutoUpdateMode {
+        switch usagePropertiesAutoUpdateMode {
+        case "foregroundOnly":
+            return .foregroundOnly
+        case "foregroundAndBackground":
+            return .foregroundAndBackground
+        case "disabled":
+            return .disabled
+        default:
+            return .foregroundOnly
+        }
     }
     
     func mapUserConsent(userConsent: String) -> ComScoreUserConsent {

--- a/comscore/react-native-theoplayer-comscore.podspec
+++ b/comscore/react-native-theoplayer-comscore.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "react-native-theoplayer"
-  s.dependency "THEOplayer-Connector-Comscore", "~> 8.0"
+  s.dependency "THEOplayer-Connector-Comscore", "~> 8.8"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.


### PR DESCRIPTION
Making `usagePropertiesAutoUpdateMode` configurable for iOS depends on changes in https://github.com/THEOplayer/iOS-Connector/pull/25. Changes in this PR were moved from https://github.com/THEOplayer/react-native-theoplayer-analytics/pull/126 