### PR TITLE
Pass MuxOptions in initialize instead of the hook itself

### DIFF
--- a/.changeset/lazy-keys-eat.md
+++ b/.changeset/lazy-keys-eat.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-mux': patch
+---
+
+Changed the `useMux` hook to allow the `MuxOptions` to be passed with the initialize instead of directly passing it into the hook itself.

--- a/mux/README.md
+++ b/mux/README.md
@@ -43,11 +43,11 @@ const muxOptions = {
 };
 
 const App = () => {
-  const [mux, initMux] = useMux(muxOptions);
+  const [mux, initMux] = useMux();
 
   const onPlayerReady = (player: THEOplayer) => {
     // Initialize connector
-    initMux(player);
+    initMux(player, muxOptions);
   }
 
   return (<THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady}/>);

--- a/mux/src/api/hooks/useMux.ts
+++ b/mux/src/api/hooks/useMux.ts
@@ -1,12 +1,13 @@
-import { PlayerEventType, THEOplayer } from 'react-native-theoplayer';
-import { RefObject, useEffect, useRef } from 'react';
-import { MuxConnector } from '@theoplayer/react-native-analytics-mux';
+import { PlayerEventType, THEOplayer } from "react-native-theoplayer";
+import { RefObject, useEffect, useRef } from "react";
+import { MuxConnector, MuxOptions } from "@theoplayer/react-native-analytics-mux";
 
-export function useMux(options: any): [RefObject<MuxConnector | undefined>, (player: THEOplayer | undefined) => void] {
+export function useMux()
+  : [RefObject<MuxConnector | undefined>, (player: THEOplayer | undefined, options: MuxOptions) => void] {
   const connector = useRef<MuxConnector | undefined>();
   const theoPlayer = useRef<THEOplayer | undefined>();
 
-  const initialize = (player: THEOplayer | undefined) => {
+  const initialize = (player: THEOplayer | undefined, options: MuxOptions) => {
     // Optionally destroy existent connector
     onDestroy();
 
@@ -15,20 +16,20 @@ export function useMux(options: any): [RefObject<MuxConnector | undefined>, (pla
       connector.current = new MuxConnector(player, options);
       player.addEventListener(PlayerEventType.DESTROY, onDestroy);
     } else {
-      throw new Error('Invalid THEOplayer instance');
+      throw new Error("Invalid THEOplayer instance");
     }
-  };
+  }
 
   const onDestroy = () => {
     if (connector.current) {
       if (!theoPlayer.current) {
-        throw new Error('Invalid THEOplayer instance');
+        throw new Error("Invalid THEOplayer instance");
       }
       theoPlayer.current.removeEventListener(PlayerEventType.DESTROY, onDestroy);
       connector.current.destroy();
       connector.current = undefined;
     }
-  };
+  }
 
   useEffect(() => {
     return onDestroy;


### PR DESCRIPTION
This PR changes the useMux hook to allow the MuxOptions to be passed with the initialize instead of directly passing it into the hook itself.
This is because the THEOplayer instance could be destroyed and recreated, but the options remained the old values.