### PR TITLE
Fixing build error starting with mux version 0.4.2 + update dependencies

### DIFF
--- a/.changeset/neat-games-wave.md
+++ b/.changeset/neat-games-wave.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-mux': patch
+---
+
+Updated dependencies on Android, allowing THEOplayer v8 and using latest Mux connector version.

--- a/mux/android/build.gradle
+++ b/mux/android/build.gradle
@@ -72,10 +72,10 @@ repositories {
 }
 
 // The Mux connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 8.0.0)')
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 9.0.0)')
 def kotlin_version = safeExtGet("THEOplayerMux_kotlinVersion", "1.9.10")
-def mux_version = safeExtGet('THEOplayerMux_muxVersion', '0.4.+')
-def mux_core_version = safeExtGet('Mux_muxVersion', '1.2.0')
+def mux_version = safeExtGet('THEOplayerMux_muxVersion', '[0.4.2, 0.5.0)')
+def mux_core_version = safeExtGet('Mux_muxVersion', '1.4.6')
 
 dependencies {
   // For < 0.71, this will be from the local maven repo
@@ -85,7 +85,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   implementation "com.mux.stats.sdk.muxstats:android:$mux_core_version"
-  implementation "com.mux.stats.sdk.muxstats:muxstatssdktheoplayer_v7:$mux_version"
+  implementation "com.mux.stats.sdk.muxstats:muxstatssdktheoplayer:$mux_version"
   implementation "com.theoplayer.theoplayer-sdk-android:core:$theoplayer_sdk_version"
   implementation "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:$theoplayer_sdk_version"
   implementation project(':react-native-theoplayer')


### PR DESCRIPTION
Starting from version 0.4.2, the version postfix is no longer required. For more details, check out [this pull request](https://github.com/muxinc/mux-stats-sdk-theoplayer-android/pull/37).

Additionally, we have updated the THEOplayer version along with the Mux Core version.
Inside [this pull request](https://github.com/muxinc/mux-stats-sdk-theoplayer-android/pull/39/files) THEOPlayer 8 will also be supported.