### PR TITLE
Bugfix/conviva/android core dep

### DIFF
--- a/.changeset/two-kids-push.md
+++ b/.changeset/two-kids-push.md
@@ -1,0 +1,6 @@
+---
+'@theoplayer/react-native-analytics-conviva': patch
+'@theoplayer/react-native-analytics-nielsen': patch
+---
+
+Added the option on Android to allow setting a different connector version using `THEOplayerName_connectorVersion`.

--- a/conviva/android/build.gradle
+++ b/conviva/android/build.gradle
@@ -88,7 +88,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
   implementation "com.conviva.sdk:conviva-core-sdk:$conviva_version"
-  implementation "com.theoplayer.android-connector:conviva:$theoplayer_sdk_version"
+  implementation "com.theoplayer.android-connector:conviva:$theoplayer_conviva_connector_version"
 
   implementation "com.theoplayer.theoplayer-sdk-android:core:$theoplayer_sdk_version"
   implementation "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:$theoplayer_sdk_version"

--- a/nielsen/android/build.gradle
+++ b/nielsen/android/build.gradle
@@ -76,6 +76,9 @@ def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 9.0.0)')
 def kotlin_version = safeExtGet("THEOplayerNielsen_kotlinVersion", "1.9.10")
 def nielsen_version = safeExtGet("THEOplayerNielsen_nielsenVersion", "9.2.0.0")
 
+// By default, take the connector version that aligns with the THEOplayer SDK version.
+def theoplayer_nielsen_connector_version = safeExtGet('THEOplayerNielsen_connectorVersion', theoplayer_sdk_version)
+
 dependencies {
   // For < 0.71, this will be from the local maven repo
   // For > 0.71, this will be replaced by `com.facebook.react:react-android:$version` by react gradle plugin
@@ -89,8 +92,7 @@ dependencies {
   compileOnly "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:$theoplayer_sdk_version"
   implementation project(':react-native-theoplayer')
 
-  // Local maven dependency: remove once published.
-  implementation "com.theoplayer.android-connector:nielsen:$theoplayer_sdk_version"
+  implementation "com.theoplayer.android-connector:nielsen:$theoplayer_nielsen_connector_version"
 
   implementation "com.nielsenappsdk.global:ad:$nielsen_version"
 


### PR DESCRIPTION
Added the option to set a different connector version than the core SDK version, for Nielsen & Conviva.