### PR TITLE
Add iOS usagePropertiesAutoUpdateMode

### DIFF
--- a/.changeset/hungry-roses-report.md
+++ b/.changeset/hungry-roses-report.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-comscore': minor
+---
+
+Passing the usagePropertiesAutoUpdateMode configuration property to the native iOS connector.

--- a/apps/e2e/ios/Podfile
+++ b/apps/e2e/ios/Podfile
@@ -16,7 +16,7 @@ install! 'cocoapods', :deterministic_uuids => false
 
 target 'ReactNativeTHEOplayer' do
 
-  platform :ios, '13.4'
+  platform :ios, '15.1'
 
   config = use_native_modules!
 
@@ -39,7 +39,7 @@ end
 
 target 'ReactNativeTHEOplayer-tvOS' do
 
-  platform :tvos, '13.4'
+  platform :tvos, '15.1'
 
   config = use_native_modules!
 

--- a/apps/e2e/ios/Podfile.lock
+++ b/apps/e2e/ios/Podfile.lock
@@ -3,19 +3,19 @@ PODS:
   - ComScore (6.10.2):
     - ComScore/Dynamic (= 6.10.2)
   - ComScore/Dynamic (6.10.2)
-  - ConvivaSDK (4.0.51)
+  - ConvivaSDK (4.0.52)
   - DoubleConversion (1.1.6)
   - DSFRegex (3.3.1)
   - FBLazyVector (0.75.4-0)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - google-cast-sdk-dynamic-xcframework (4.8.0)
-  - GoogleAds-IMA-iOS-SDK (3.23.0)
-  - GoogleAds-IMA-tvOS-SDK (4.9.1)
+  - google-cast-sdk-dynamic-xcframework (4.8.3)
+  - GoogleAds-IMA-iOS-SDK (3.24.0)
+  - GoogleAds-IMA-tvOS-SDK (4.14.1)
   - hermes-engine (0.75.4-0):
     - hermes-engine/Pre-built (= 0.75.4-0)
   - hermes-engine/Pre-built (0.75.4-0)
-  - NielsenAppSDK-XC (9.0.0.0)
+  - NielsenAppSDK-XC (9.4.0.0)
   - PromisesObjC (2.4.0)
   - RCT-Folly (2024.01.01.00):
     - boost
@@ -1277,25 +1277,82 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-theoplayer (8.12.0):
+  - react-native-theoplayer (8.13.0):
     - React-Core
     - THEOplayer-Connector-SideloadedSubtitle (~> 8.6)
     - THEOplayer-Integration-GoogleCast (~> 8.6)
     - THEOplayer-Integration-GoogleIMA (~> 8.6)
     - THEOplayer-Integration-THEOlive (>= 8.6.3, ~> 8.6)
     - THEOplayerSDK-core (~> 8.6)
-  - react-native-theoplayer-comscore (1.8.0):
+  - react-native-theoplayer-comscore (1.8.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
     - react-native-theoplayer
-    - THEOplayer-Connector-Comscore (~> 8.0)
-  - react-native-theoplayer-conviva (1.8.0):
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - THEOplayer-Connector-Comscore (~> 8.8)
+    - Yoga
+  - react-native-theoplayer-conviva (1.8.3):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
     - react-native-theoplayer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - THEOplayer-Connector-Conviva (~> 8.0)
-  - react-native-theoplayer-nielsen (1.7.0):
+    - Yoga
+  - react-native-theoplayer-nielsen (1.7.3):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
     - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
     - react-native-theoplayer
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
     - THEOplayer-Connector-Nielsen (~> 8.0)
+    - Yoga
   - React-nativeconfig (0.75.4-0)
   - React-NativeModulesApple (0.75.4-0):
     - glog
@@ -1565,45 +1622,45 @@ PODS:
   - SwiftSubtitles (0.9.1):
     - DSFRegex (~> 3.3.1)
     - TinyCSV (~> 0.6.1)
-  - THEOliveSDK (3.18.6)
-  - THEOplayer-Connector-Comscore (8.7.0):
+  - THEOliveSDK (3.18.10)
+  - THEOplayer-Connector-Comscore (8.12.0):
     - ComScore (~> 6.10.0)
     - THEOplayerSDK-core (~> 8)
-  - THEOplayer-Connector-Conviva (8.7.0):
+  - THEOplayer-Connector-Conviva (8.12.0):
     - ConvivaSDK (~> 4.0.30)
-    - THEOplayer-Connector-Utilities (>= 8.7.0, ~> 8.7)
+    - THEOplayer-Connector-Utilities (>= 8.12.0, ~> 8.12)
     - THEOplayerSDK-core (~> 8)
-  - THEOplayer-Connector-Nielsen (8.0.0):
-    - NielsenAppSDK-XC (= 9.0.0.0)
-    - THEOplayer-Connector-Utilities (>= 8.0.0, ~> 8.0)
+  - THEOplayer-Connector-Nielsen (8.12.0):
+    - NielsenAppSDK-XC (~> 9)
+    - THEOplayer-Connector-Utilities (>= 8.12.0, ~> 8.12)
     - THEOplayerSDK-core (~> 8)
-  - THEOplayer-Connector-SideloadedSubtitle (8.7.0):
+  - THEOplayer-Connector-SideloadedSubtitle (8.12.0):
     - Swifter (= 1.5.0)
     - SwiftSubtitles (= 0.9.1)
     - THEOplayerSDK-core (~> 8)
-  - THEOplayer-Connector-Utilities (8.7.0):
+  - THEOplayer-Connector-Utilities (8.12.0):
     - ConvivaSDK (~> 4.0.30)
     - THEOplayerSDK-core (~> 8)
-  - THEOplayer-Integration-GoogleCast (8.7.0):
-    - THEOplayer-Integration-GoogleCast/Base (= 8.7.0)
-    - THEOplayer-Integration-GoogleCast/Dependencies (= 8.7.0)
-  - THEOplayer-Integration-GoogleCast/Base (8.7.0)
-  - THEOplayer-Integration-GoogleCast/Dependencies (8.7.0):
+  - THEOplayer-Integration-GoogleCast (8.12.0):
+    - THEOplayer-Integration-GoogleCast/Base (= 8.12.0)
+    - THEOplayer-Integration-GoogleCast/Dependencies (= 8.12.0)
+  - THEOplayer-Integration-GoogleCast/Base (8.12.0)
+  - THEOplayer-Integration-GoogleCast/Dependencies (8.12.0):
     - google-cast-sdk-dynamic-xcframework (~> 4.8)
-  - THEOplayer-Integration-GoogleIMA (8.7.0):
-    - THEOplayer-Integration-GoogleIMA/Base (= 8.7.0)
-    - THEOplayer-Integration-GoogleIMA/Dependencies (= 8.7.0)
-  - THEOplayer-Integration-GoogleIMA/Base (8.7.0)
-  - THEOplayer-Integration-GoogleIMA/Dependencies (8.7.0):
+  - THEOplayer-Integration-GoogleIMA (8.12.0):
+    - THEOplayer-Integration-GoogleIMA/Base (= 8.12.0)
+    - THEOplayer-Integration-GoogleIMA/Dependencies (= 8.12.0)
+  - THEOplayer-Integration-GoogleIMA/Base (8.12.0)
+  - THEOplayer-Integration-GoogleIMA/Dependencies (8.12.0):
     - GoogleAds-IMA-iOS-SDK (~> 3.18)
     - GoogleAds-IMA-tvOS-SDK (~> 4.8)
-  - THEOplayer-Integration-THEOlive (8.7.0):
-    - THEOplayer-Integration-THEOlive/Base (= 8.7.0)
-    - THEOplayer-Integration-THEOlive/Dependencies (= 8.7.0)
-  - THEOplayer-Integration-THEOlive/Base (8.7.0)
-  - THEOplayer-Integration-THEOlive/Dependencies (8.7.0):
-    - THEOliveSDK (= 3.18.6)
-  - THEOplayerSDK-core (8.7.0)
+  - THEOplayer-Integration-THEOlive (8.12.0):
+    - THEOplayer-Integration-THEOlive/Base (= 8.12.0)
+    - THEOplayer-Integration-THEOlive/Dependencies (= 8.12.0)
+  - THEOplayer-Integration-THEOlive/Base (8.12.0)
+  - THEOplayer-Integration-THEOlive/Dependencies (8.12.0):
+    - THEOliveSDK (= 3.18.10)
+  - THEOplayerSDK-core (8.12.0)
   - TinyCSV (0.6.1)
   - Yoga (0.0.0)
 
@@ -1859,17 +1916,17 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   boost: d70f09e8edc61001a5cd2131f47cca76f9b3f031
   ComScore: 3669769a26adf769adddc51ffa34e48ee51a8661
-  ConvivaSDK: c5d877bf5a830a8dd0b0696c538a11fc96208ec5
+  ConvivaSDK: 79ad3a5b0b68d575a2e62c09d2311e0db600fec7
   DoubleConversion: 00143ab27d470b28035933623e1a3ea37e68889c
   DSFRegex: 8493187c71ac199695245eb9ec98bad4f87a2f0b
   FBLazyVector: e06894178a2469b6da988d1d4de56aca5a3f90d1
   fmt: 1568fa7b2f242362c45c42d4a15e9dd4b2e621b3
   glog: 4d211b5b727f9d4542418484bf9945f28b8cb4a5
-  google-cast-sdk-dynamic-xcframework: d1323732742c979b2d7e5b061cbe665915981f3d
-  GoogleAds-IMA-iOS-SDK: ee2a68ed7a1a17c7bb81bdb1b81590b35a3fc8f3
-  GoogleAds-IMA-tvOS-SDK: 85e799c35051454693492480ef7e4ae2e701a05f
+  google-cast-sdk-dynamic-xcframework: d4dd8d548462f2a4874515fee68c17805d44be42
+  GoogleAds-IMA-iOS-SDK: bf4dc86b31a1d1b27021008200bbeb6faa689901
+  GoogleAds-IMA-tvOS-SDK: f1efc14f85842b0858528dfe5220adfee637a6da
   hermes-engine: ac68d6c3169772a7a7f9eeb25dbb5ff87930034f
-  NielsenAppSDK-XC: 8877317bed8261bc6bdcb7d8655f5ba314ba9610
+  NielsenAppSDK-XC: a32c6b55d158dde2366152fe13406dea588929d6
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: 4728c42e04357ad445c7048e7c542b59f3ee6b4f
   RCTDeprecation: 3d8708756d84c6f6bce6b0e538bbc109ada51385
@@ -1902,10 +1959,10 @@ SPEC CHECKSUMS:
   React-microtasksnativemodule: a3489ca37b515f6f685ec1a86c8df364343ac578
   react-native-google-cast: d7bdfd1a0eeba84afde03b9722351ec29543e74c
   react-native-slider: 4a0f3386a38fc3d2d955efc515aef7096f7d1ee4
-  react-native-theoplayer: c2c094bb3e7ba7d0925ad772e512c0dd6d22a876
-  react-native-theoplayer-comscore: 9bb314d14fce9a85b4d401c49dde543505f92571
-  react-native-theoplayer-conviva: 06bf2a49aa0d92581faaab8275ed272cfe1f298a
-  react-native-theoplayer-nielsen: 8b42c94347d860826fe61298b3023562833249ac
+  react-native-theoplayer: 055216a08b06a49884c1a088b3c6e2690a49f013
+  react-native-theoplayer-comscore: 062a9bda65b2d51a073703caa188f44bf0547741
+  react-native-theoplayer-conviva: c71d6e231a3e380aa3e64b257e661e984c0c0fee
+  react-native-theoplayer-nielsen: 0694bc55fc520007f44ac5db3f11575bfbf302e4
   React-nativeconfig: ea22f0ab525feb865d2e0ed5d7aad156c36abe6b
   React-NativeModulesApple: 5efee2e69aaa7ff47f40a2918f2b48534a2e431b
   React-perflogger: f31660a8693c3444e1832c237ba25a13f613436e
@@ -1937,19 +1994,19 @@ SPEC CHECKSUMS:
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
   Swifter: e71dd674404923d7f03ebb03f3f222d1c570bc8e
   SwiftSubtitles: c659af19d710a2946779015464c0577d07fe4666
-  THEOliveSDK: 109b31511177686012f5e475c32edc40e2e52e9f
-  THEOplayer-Connector-Comscore: 1b96e6f0aaad9fe7bd01ceaa05d4514cd557c5fb
-  THEOplayer-Connector-Conviva: 446d2727163b36b75b6d7a67e40806046e875fbe
-  THEOplayer-Connector-Nielsen: cb2d511f62f212d8e7a20660c4a6bfb8508d00a5
-  THEOplayer-Connector-SideloadedSubtitle: baa1d8ab128928054e7e6576565464ef007d2af7
-  THEOplayer-Connector-Utilities: c0ad1d3daf6d2339266ef3dc3a0ede19fbbb9d4f
-  THEOplayer-Integration-GoogleCast: 927c7a696aad7d0a39d7130d1775437694538bd8
-  THEOplayer-Integration-GoogleIMA: 846990b5c88d74bb17e712fbf883691dbc9269eb
-  THEOplayer-Integration-THEOlive: 258d439e0823493810c74947005dd26ebfa7f57d
-  THEOplayerSDK-core: 1007db3c8d6ab156b9a8f2f8a4f4f07ef1ca00fc
+  THEOliveSDK: 61479e7ad8164340a8aaccc211493e2606d4381d
+  THEOplayer-Connector-Comscore: 3726d5f614c88fbdab8491d168528db9cf8285ad
+  THEOplayer-Connector-Conviva: 4c3808d85bb239f589efa57b9fcab4da087569d8
+  THEOplayer-Connector-Nielsen: 5daccab12e8d28bb75f2ce3fb093f95448f3f348
+  THEOplayer-Connector-SideloadedSubtitle: 5c05cb2629e62d59c740e04645005507c4ab557e
+  THEOplayer-Connector-Utilities: befa8ebe0599ae4ad5c295cece8d85b9a83bdb5d
+  THEOplayer-Integration-GoogleCast: 36e5453692708431454e1e0a0716a4b2c22d50a1
+  THEOplayer-Integration-GoogleIMA: 7558ba195d99be6415e2ee8e07bd55a195a8d8d3
+  THEOplayer-Integration-THEOlive: de905c896255872da9e5171f245e73229b1c5c56
+  THEOplayerSDK-core: dccbcb96da4ad44fd2febc9dccc39500512622bc
   TinyCSV: fd6228edbcf1c07466ac34b76dac5e052143eaba
-  Yoga: 07ebe50bd234e51e5e3e07befa14a3078a0fcbbd
+  Yoga: 1eb8c4882b3018c344a2ff61c5f2e5c6b1711d82
 
-PODFILE CHECKSUM: 1db78314a52c67a8fe96e168cc72c5c8034f398c
+PODFILE CHECKSUM: baa77347c1627215315b6f99b250aab99cddbb2e
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/apps/e2e/ios/ReactNativeTHEOplayer-tvOS/Info.plist
+++ b/apps/e2e/ios/ReactNativeTHEOplayer-tvOS/Info.plist
@@ -35,6 +35,8 @@
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Tracking video analytics for Conviva</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/apps/e2e/ios/ReactNativeTHEOplayer/Info.plist
+++ b/apps/e2e/ios/ReactNativeTHEOplayer/Info.plist
@@ -37,6 +37,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Bluetooth Always Usage Permission</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_googlecast._tcp</string>
@@ -44,10 +46,8 @@
 	</array>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Local Network Usage Permission</string>
-	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>Bluetooth Always Usage Permission</string>
 	<key>NSUserTrackingUsageDescription</key>
-	<string>Just for fun</string>
+	<string>Tracking video analytics for Conviva</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/apps/e2e/ios/ReactNativeTHEOplayer/Info.plist
+++ b/apps/e2e/ios/ReactNativeTHEOplayer/Info.plist
@@ -46,6 +46,8 @@
 	<string>Local Network Usage Permission</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Bluetooth Always Usage Permission</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>Just for fun</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>

--- a/apps/e2e/src/tests/Comscore.spec.ts
+++ b/apps/e2e/src/tests/Comscore.spec.ts
@@ -3,6 +3,7 @@ import {
   ComscoreConfiguration,
   ComscoreConnector,
   ComscoreMetadata,
+  ComscoreUsagePropertiesAutoUpdateMode,
   ComscoreUserConsent
 } from '@theoplayer/react-native-analytics-comscore';
 import {ComscoreMediaType} from '@theoplayer/react-native-analytics-comscore/src/api/ComscoreMetadata';
@@ -26,6 +27,7 @@ export default function (spec: TestScope) {
       publisherId: 'publisherId',
       applicationName: 'applicationName',
       userConsent: ComscoreUserConsent.granted,
+      usagePropertiesAutoUpdateMode: ComscoreUsagePropertiesAutoUpdateMode.foregroundAndBackground,
       debug: true
     };
 

--- a/comscore/ios/THEOplayerComscoreRCTComscoreAPI.swift
+++ b/comscore/ios/THEOplayerComscoreRCTComscoreAPI.swift
@@ -31,6 +31,7 @@ class THEOplayerComscoreRCTComscoreAPI: NSObject, RCTBridgeModule {
                     publisherId: ComscoreConfig["publisherId"] as! String,
                     applicationName: ComscoreConfig["applicationName"] as! String,
                     userConsent: self.mapUserConsent(userConsent: ComscoreConfig["userConsent"] as! String),
+                    usagePropertiesAutoUpdateMode: self.mapUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode: ComscoreConfig["usagePropertiesAutoUpdateMode"] as? String ?? "foregroundOnly"),
                     adIdProcessor: nil,
                     debug: ComscoreConfig["debug"] as! Bool
                 )
@@ -140,6 +141,19 @@ class THEOplayerComscoreRCTComscoreAPI: NSObject, RCTBridgeModule {
             customLabels: metadata["customLabels"] as? [String:String]
         )
         return comscoreMetadata
+    }
+    
+    func mapUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode: String) -> ComscoreUsagePropertiesAutoUpdateMode {
+        switch usagePropertiesAutoUpdateMode {
+        case "foregroundOnly":
+            return .foregroundOnly
+        case "foregroundAndBackground":
+            return .foregroundAndBackground
+        case "disabled":
+            return .disabled
+        default:
+            return .foregroundOnly
+        }
     }
     
     func mapUserConsent(userConsent: String) -> ComScoreUserConsent {

--- a/comscore/react-native-theoplayer-comscore.podspec
+++ b/comscore/react-native-theoplayer-comscore.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
 
   s.dependency "react-native-theoplayer"
-  s.dependency "THEOplayer-Connector-Comscore", "~> 8.0"
+  s.dependency "THEOplayer-Connector-Comscore", "~> 8.8"
 
   # Use install_modules_dependencies helper to install the dependencies if React Native version >=0.71.0.
   # See https://github.com/facebook/react-native/blob/febf6b7f33fdb4904669f99d795eba4c0f95d7bf/scripts/cocoapods/new_architecture.rb#L79.

--- a/conviva/ios/THEOplayerConvivaRCTConvivaAPI.swift
+++ b/conviva/ios/THEOplayerConvivaRCTConvivaAPI.swift
@@ -35,12 +35,12 @@ class THEOplayerConvivaRCTConvivaAPI: NSObject, RCTBridgeModule {
                 if let connector = ConvivaConnector( configuration: configuration, player: player, externalEventDispatcher: view.broadcastEventHandler) {
                     connector.setErrorCallback(onNativeError: view.mainEventHandler.onNativeError)
                     self.connectors[node] = connector
-                    log("added connector to view \(node)")
                     if let contentInfo = convivaMetadata as? [String: Any] {
                         connector.setContentInfo(contentInfo)
                     } else {
                         log("Received metadata in wrong format. Received \(convivaMetadata), expected [String: Any]")
                     }
+                    log("Added connector to view \(node)")
                 } else {
                     log("Cannot create Conviva connector for node \(node)")
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,7 +126,7 @@
     },
     "conviva": {
       "name": "@theoplayer/react-native-analytics-conviva",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "@convivainc/conviva-js-coresdk": "^4.7.9",
@@ -157,7 +157,7 @@
     },
     "mux": {
       "name": "@theoplayer/react-native-analytics-mux",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "@mux/mux-data-theoplayer": "^4.17.1"
@@ -176,7 +176,7 @@
     },
     "nielsen": {
       "name": "@theoplayer/react-native-analytics-nielsen",
-      "version": "1.7.2",
+      "version": "1.7.3",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "@theoplayer/nielsen-connector-web": "^1.2.0"


### PR DESCRIPTION
Making `usagePropertiesAutoUpdateMode` configurable for iOS depends on changes in https://github.com/THEOplayer/iOS-Connector/pull/25. Changes in this PR were moved from https://github.com/THEOplayer/react-native-theoplayer-analytics/pull/126 