### PR TITLE
Bugfix/adobe/end session

### DIFF
--- a/.changeset/clever-areas-stay.md
+++ b/.changeset/clever-areas-stay.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-adobe': patch
+---
+
+Fixed an issue where heart-beat requests could continue after destroying a session on Web.

--- a/adobe/src/internal/DefaultAdobeConnectorAdapter.ts
+++ b/adobe/src/internal/DefaultAdobeConnectorAdapter.ts
@@ -466,6 +466,7 @@ export class DefaultAdobeConnectorAdapter implements AdobeConnectorAdapter {
 
   async destroy(): Promise<void> {
     await this.maybeEndSession();
+    this.reset();
     this.removeEventListeners();
   }
 


### PR DESCRIPTION
Fixed an edge-case where heart-beat requests could continue on Web after destroying the connector.