### PR TITLE
feat(bitmovin): expose current impression ID getter

### DIFF
--- a/.changeset/bright-cats-impress.md
+++ b/.changeset/bright-cats-impress.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-bitmovin': minor
+---
+
+Add a getter for the current Bitmovin analytics impression ID.

--- a/.changeset/bright-cats-impress.md
+++ b/.changeset/bright-cats-impress.md
@@ -2,4 +2,4 @@
 '@theoplayer/react-native-analytics-bitmovin': minor
 ---
 
-Add a getter for the current Bitmovin analytics impression ID.
+Added a getter for the current Bitmovin `impressionId`.

--- a/apps/e2e/src/tests/Bitmovin.spec.ts
+++ b/apps/e2e/src/tests/Bitmovin.spec.ts
@@ -36,7 +36,7 @@ export default function (spec: TestScope) {
           },
         });
       },
-      () => {
+      async () => {
         connector.updateCustomData({
           customData0: 'newValue0',
           customData1: 'newValue1',
@@ -48,6 +48,7 @@ export default function (spec: TestScope) {
             customData10: 'newValue10',
           },
         });
+        await connector.getImpressionId();
       },
       () => {
         connector.destroy();

--- a/bitmovin/README.md
+++ b/bitmovin/README.md
@@ -108,3 +108,12 @@ bitmovin.programChange({
   }
 });
 ```
+
+### Getting the current impression ID
+
+The current impression ID can be retrieved asynchronously. The promise resolves to `undefined` when
+there is no active impression or analytics session:
+
+```tsx
+const impressionId = await bitmovin.getImpressionId();
+```

--- a/bitmovin/android/src/main/java/com/theoplayer/reactnative/bitmovin/BitmovinHandler.kt
+++ b/bitmovin/android/src/main/java/com/theoplayer/reactnative/bitmovin/BitmovinHandler.kt
@@ -42,6 +42,9 @@ class BitmovinHandler(
       collector.customData = mergeCustomData( value, collector.customData)
     }
 
+  val impressionId: String?
+    get() = collector.impressionId
+
   fun programChange(sourceMetadata: SourceMetadata) {
     collector.programChange(sourceMetadata)
   }

--- a/bitmovin/android/src/main/java/com/theoplayer/reactnative/bitmovin/ReactTHEOplayerBitmovinModule.kt
+++ b/bitmovin/android/src/main/java/com/theoplayer/reactnative/bitmovin/ReactTHEOplayerBitmovinModule.kt
@@ -62,6 +62,13 @@ class ReactTHEOplayerBitmovinModule(val context: ReactApplicationContext) :
   }
 
   @ReactMethod
+  fun getImpressionId(tag: Int, promise: Promise) {
+    context.runOnUiQueueThread {
+      promise.resolve(bitmovinConnectors[tag]?.impressionId)
+    }
+  }
+
+  @ReactMethod
   fun destroy(tag: Int) {
     context.runOnUiQueueThread {
       bitmovinConnectors[tag]?.destroy()

--- a/bitmovin/ios/Connector/BitmovinHandler.swift
+++ b/bitmovin/ios/Connector/BitmovinHandler.swift
@@ -42,6 +42,10 @@ class BitmovinHandler {
         self.theoplayerCollector.sendCustomDataEvent(with: BitmovinAdapter.parseCustomData(customData))
         log("Custom data event send with custom data: \(customData)")
     }
+
+    var impressionId: String? {
+        return self.theoplayerCollector.impressionId
+    }
     
     func destroy() -> Void {
         self.detachListeners()

--- a/bitmovin/ios/THEOplayerBitmovinRCTBitmovinAPI.swift
+++ b/bitmovin/ios/THEOplayerBitmovinRCTBitmovinAPI.swift
@@ -81,6 +81,14 @@ class THEOplayerBitmovinRCTBitmovinAPI: NSObject, RCTBridgeModule {
             }
         }
     }
+
+    @objc(getImpressionId:resolver:rejecter:)
+    func getImpressionId(_ node: NSNumber, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        log("getImpressionId triggered.")
+        DispatchQueue.main.async {
+            resolve(self.connectors[node]?.impressionId)
+        }
+    }
     
     @objc(destroy:)
     func destroy(_ node: NSNumber) -> Void {

--- a/bitmovin/ios/THEOplayerBitmovinRCTBridge.m
+++ b/bitmovin/ios/THEOplayerBitmovinRCTBridge.m
@@ -19,6 +19,10 @@ RCT_EXTERN_METHOD(programChange:(nonnull NSNumber *)node sourceMetadata:(nonnull
 
 RCT_EXTERN_METHOD(sendCustomDataEvent:(nonnull NSNumber *)node customData:(nonnull NSDictionary *)customData)
 
+RCT_EXTERN_METHOD(getImpressionId:(nonnull NSNumber *)node
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(destroy:(nonnull NSNumber *)node)
 
 @end

--- a/bitmovin/src/api/BitmovinConnector.ts
+++ b/bitmovin/src/api/BitmovinConnector.ts
@@ -59,6 +59,15 @@ export class BitmovinConnector {
   }
 
   /**
+   * Returns the impression ID of the current analytics session.
+   *
+   * Resolves to `undefined` when there is no active impression or session.
+   */
+  getImpressionId(): Promise<string | undefined> {
+    return this.connectorAdapter.getImpressionId();
+  }
+
+  /**
    * Stops video and ad analytics and closes all sessions.
    */
   destroy(): void {

--- a/bitmovin/src/internal/BitmovinConnectorAdapter.ts
+++ b/bitmovin/src/internal/BitmovinConnectorAdapter.ts
@@ -52,6 +52,18 @@ export class BitmovinConnectorAdapter {
     }
   }
 
+  getImpressionId(): Promise<string | undefined> {
+    try {
+      return Promise.resolve(NativeModules.BitmovinModule.getImpressionId(this.nativeHandle)).catch((error: unknown) => {
+        console.error(TAG, `${ERROR_MSG}: ${error}`);
+        return undefined;
+      });
+    } catch (error: unknown) {
+      console.error(TAG, `${ERROR_MSG}: ${error}`);
+      return Promise.resolve(undefined);
+    }
+  }
+
   destroy(): void {
     try {
       NativeModules.BitmovinModule.destroy(this.nativeHandle);

--- a/bitmovin/src/internal/BitmovinConnectorAdapter.web.ts
+++ b/bitmovin/src/internal/BitmovinConnectorAdapter.web.ts
@@ -33,6 +33,10 @@ export class BitmovinConnectorAdapter {
     this.integration.setCustomDataOnce(customData);
   }
 
+  getImpressionId(): Promise<string | undefined> {
+    return Promise.resolve(this.integration.getCurrentImpressionId());
+  }
+
   destroy() {
     /**
      * We can safely disable the BITMOVIN_ANALYTICS_AUGMENTED_MARKER here to avoid duplicate connectors being attached to the same player instance,


### PR DESCRIPTION
## Summary

Exposes the Bitmovin analytics **impression ID** through a new getter on the Bitmovin connector, backed on web, Android and iOS.

```ts
const impressionId: string | undefined = await bitmovin.getImpressionId();
```

The getter is async because Android/iOS read the value across the native bridge. It resolves to `undefined` when there is no active impression/analytics session. Each platform reads the id straight from the underlying Bitmovin collector:

- **Web** — `THEOplayerAdapter.getCurrentImpressionId()` (`bitmovin-analytics`)
- **Android** — `collector.impressionId` on `ITHEOplayerCollector`, surfaced via a new `Promise`-based `@ReactMethod getImpressionId(tag, promise)`
- **iOS** — `theoplayerCollector.impressionId`, surfaced via a new `RCTPromiseResolveBlock`-based `getImpressionId` bridge method (dispatched on the main queue)

Wiring mirrors the existing connector methods: public `BitmovinConnector.getImpressionId()` → `BitmovinConnectorAdapter` (native + `.web`) → native module. This is the first return-value (Promise) method on this connector; the existing methods are all fire-and-forget.

## Changes
- `src/api/BitmovinConnector.ts` — public `getImpressionId(): Promise<string | undefined>`
- `src/internal/BitmovinConnectorAdapter.ts` / `.web.ts` — native + web adapter implementations
- `android/.../ReactTHEOplayerBitmovinModule.kt` + `BitmovinHandler.kt` — Promise bridge + collector accessor
- `ios/THEOplayerBitmovinRCTBridge.m` + `THEOplayerBitmovinRCTBitmovinAPI.swift` + `BitmovinHandler.swift` — Promise bridge + collector accessor
- `README.md` — usage section
- `apps/e2e/src/tests/Bitmovin.spec.ts` — smoke test awaiting `getImpressionId()`
- `.changeset/bright-cats-impress.md` — minor bump

## Testing
- `tsc --noEmit`, eslint (0 errors), typedoc, and web `bob build` pass; changed files are Prettier-clean.
- Native builds can't run in the current environment (Android needs the sibling `react-native-theoplayer` project; iOS requires macOS). Native accessors were verified against the actual Bitmovin SDK artifacts (`collector-*.aar` via `javap`, `CoreCollector.xcframework` interface).


Link to Devin session: https://dolby.devinenterprise.com/sessions/e2dc4394cc59467784a580e3f3bf95f8
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->