### PR TITLE
Reset player before each test

### DIFF
--- a/apps/e2e/patches/cavy+4.0.2.patch
+++ b/apps/e2e/patches/cavy+4.0.2.patch
@@ -1,24 +1,29 @@
 diff --git a/node_modules/cavy/src/Reporter.js b/node_modules/cavy/src/Reporter.js
-index 1cdeb38..24ae1f7 100644
+index 1cdeb38..4dc4d37 100644
 --- a/node_modules/cavy/src/Reporter.js
 +++ b/node_modules/cavy/src/Reporter.js
-@@ -9,7 +9,31 @@ export default class Reporter {
+@@ -8,8 +8,36 @@ export default class Reporter {
+ 
    // Internal: Creates a websocket connection to the cavy-cli server.
    onStart() {
-     const url = 'ws://127.0.0.1:8082/';
-+    console.debug('Creating websocket');
-     this.ws = new WebSocket(url);
-+    this.ws.onerror = console.error
-+    this.ws.onopen = () => {
-+      console.debug('Successfully opened websocket');
-+    }
-+    this.ws.onclose = () => {
-+      console.debug('Closing websocket');
-+    }
-+
 +    this.overrideConsole('log');
 +    this.overrideConsole('debug');
 +    this.overrideConsole('warn');
++
+     const url = 'ws://127.0.0.1:8082/';
++    console.debug('Creating websocket');
+     this.ws = new WebSocket(url);
++    this.ws.onerror = console.error;
++    this.ws.onclose = () => {
++      console.debug('Closing websocket');
++    };
++
++    return new Promise((resolve) => {
++      this.ws.onopen = () => {
++        console.debug('Successfully opened websocket');
++        resolve();
++      };
++    });
 +  }
 +
 +  overrideConsole(fn) {
@@ -34,7 +39,7 @@ index 1cdeb38..24ae1f7 100644
    }
  
    // Internal: Send a single test result to cavy-cli over the websocket connection.
-@@ -20,6 +44,13 @@ export default class Reporter {
+@@ -20,6 +48,13 @@ export default class Reporter {
      }
    }
  
@@ -48,7 +53,7 @@ index 1cdeb38..24ae1f7 100644
    // Internal: Send report to cavy-cli over the websocket connection.
    onFinish(report) {
      if (this.websocketReady()) {
-@@ -34,7 +65,6 @@ export default class Reporter {
+@@ -34,11 +69,10 @@ export default class Reporter {
        console.log(message);
      }
    }
@@ -56,6 +61,11 @@ index 1cdeb38..24ae1f7 100644
    // Private: Determines whether data can be sent over the websocket.
    websocketReady() {
      // WebSocket.readyState 1 means the web socket connection is OPEN.
+-    return this.ws.readyState == 1;
++    return this.ws && this.ws.readyState == 1;
+   }
+ 
+   // Private: Sends data over the websocket and console logs any errors.
 diff --git a/node_modules/cavy/src/TestRunner.js b/node_modules/cavy/src/TestRunner.js
 index 40552bf..0af9639 100644
 --- a/node_modules/cavy/src/TestRunner.js
@@ -70,10 +80,10 @@ index 40552bf..0af9639 100644
  
        this.results.push({
 diff --git a/node_modules/cavy/src/Tester.js b/node_modules/cavy/src/Tester.js
-index c61e31a..8d222ae 100644
+index c61e31a..82c6650 100644
 --- a/node_modules/cavy/src/Tester.js
 +++ b/node_modules/cavy/src/Tester.js
-@@ -57,20 +57,8 @@ export default class Tester extends Component {
+@@ -57,28 +57,16 @@ export default class Tester extends Component {
        key: Math.random()
      };
      this.testHookStore = props.store;
@@ -95,4 +105,15 @@ index c61e31a..8d222ae 100644
 +    this.reporter = new reporterClass;
    }
  
-   componentDidMount() {
+-  componentDidMount() {
+-    this.runTests();
++  async componentDidMount() {
+     if (!(this.reporter instanceof Function)
+       && this.reporter.type == 'realtime' ) {
+-      this.reporter.onStart();
++      await this.reporter.onStart();
+     }
++    this.runTests();
+   }
+ 
+   // Run all test suites.

--- a/apps/e2e/patches/cavy+4.0.2.patch
+++ b/apps/e2e/patches/cavy+4.0.2.patch
@@ -13,7 +13,7 @@ index 1cdeb38..4dc4d37 100644
      const url = 'ws://127.0.0.1:8082/';
 +    console.debug('Creating websocket');
      this.ws = new WebSocket(url);
-+    this.ws.onerror = console.error;
+     this.ws = new WebSocket(url);
 +    this.ws.onclose = () => {
 +      console.debug('Closing websocket');
 +    };

--- a/apps/e2e/patches/cavy+4.0.2.patch
+++ b/apps/e2e/patches/cavy+4.0.2.patch
@@ -49,7 +49,7 @@ index 1cdeb38..4dc4d37 100644
  
 +  sendMessage(data) {
 +    if (this.websocketReady()) {
-+      testData = { event: 'message', data };
++      const testData = { event: 'message', data };
 +      this.sendData(testData);
 +    }
 +  }

--- a/apps/e2e/patches/cavy+4.0.2.patch
+++ b/apps/e2e/patches/cavy+4.0.2.patch
@@ -18,10 +18,14 @@ index 1cdeb38..4dc4d37 100644
 +      console.debug('Closing websocket');
 +    };
 +
-+    return new Promise((resolve) => {
++    return new Promise((resolve, reject) => {
 +      this.ws.onopen = () => {
 +        console.debug('Successfully opened websocket');
 +        resolve();
++      };
++      this.ws.onerror = (err) => {
++        console.error('WebSocket error', err);
++        reject(err);
 +      };
 +    });
 +  }

--- a/apps/e2e/src/components/TestableTHEOplayerView.tsx
+++ b/apps/e2e/src/components/TestableTHEOplayerView.tsx
@@ -44,16 +44,21 @@ export const getTestPlayer = async (timeout = 5000, poll = 200): Promise<THEOpla
 
 export const TestableTHEOplayerView = (props: THEOplayerViewProps) => {
   const generateTestHook = useCavy();
+  const playerIdRef = React.useRef<number | undefined>(undefined);
+
   const onPlayerReady = useCallback((player: THEOplayer) => {
     testPlayerId++;
+    playerIdRef.current = testPlayerId;
     testPlayer = player;
     console.debug(`[onPlayerReady] id: ${testPlayerId}`);
     props.onPlayerReady?.(player);
   }, []);
 
   const onPlayerDestroy = useCallback(() => {
-    console.debug(`[onPlayerDestroy] id: ${testPlayerId}`);
-    testPlayer = undefined;
+    console.debug(`[onPlayerDestroy] id: ${playerIdRef.current}`);
+    if (playerIdRef.current === testPlayerId) {
+      testPlayer = undefined;
+    }
   }, []);
 
   return <THEOplayerView ref={generateTestHook('Scene.THEOplayerView')} {...props} onPlayerReady={onPlayerReady} onPlayerDestroy={onPlayerDestroy} />;

--- a/apps/e2e/src/components/TestableTHEOplayerView.tsx
+++ b/apps/e2e/src/components/TestableTHEOplayerView.tsx
@@ -6,6 +6,13 @@ let testPlayer: THEOplayer | undefined = undefined;
 let testPlayerId: number = 0;
 
 /**
+ * Reset the test player reference so that getTestPlayer waits for a fresh instance.
+ */
+export const resetTestPlayer = () => {
+  testPlayer = undefined;
+};
+
+/**
  * Wait until the player is ready.
  *
  * @param timeout Delay after rejecting the player.

--- a/apps/e2e/src/tests/ConnectorUtils.ts
+++ b/apps/e2e/src/tests/ConnectorUtils.ts
@@ -1,6 +1,6 @@
 import { TestScope } from 'cavy';
 import hls from '../res/hls.json';
-import { getTestPlayer } from '../components/TestableTHEOplayerView';
+import { getTestPlayer, resetTestPlayer } from '../components/TestableTHEOplayerView';
 import { PlayerEventType, THEOplayer } from 'react-native-theoplayer';
 import { waitForPlayerEventTypes } from '../utils/Actions';
 
@@ -9,6 +9,7 @@ const NoOpPlayerFn: PlayerFn = (_player: THEOplayer) => {};
 
 export function testConnector(spec: TestScope, onCreate: PlayerFn, onUseAPI: PlayerFn, onDestroy: PlayerFn) {
   spec.it('successfully creates the connector, connects to the player, uses API, and cleans up and destroys.', async function () {
+    resetTestPlayer();
     const player = await getTestPlayer();
 
     // Create connector.

--- a/apps/e2e/src/utils/Actions.ts
+++ b/apps/e2e/src/utils/Actions.ts
@@ -11,7 +11,7 @@ import {
   StringKeyOf,
   THEOplayer,
 } from 'react-native-theoplayer';
-import { getTestPlayer } from '../components/TestableTHEOplayerView';
+import { getTestPlayer, resetTestPlayer } from '../components/TestableTHEOplayerView';
 import { logPlayerBuffer } from './PlayerUtils';
 
 export interface TestOptions {
@@ -23,6 +23,7 @@ export const defaultTestOptions: TestOptions = {
 };
 
 export async function preparePlayerWithSource(source: SourceDescription, autoplay: boolean = true): Promise<THEOplayer> {
+  resetTestPlayer();
   const player = await getTestPlayer();
   let startUpPromise: Promise<Event<PlayerEventType>[]>;
   if (autoplay) {


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

**assumption:**

1. reRender() — schedules setState, React hasn't flushed yet
2. getTestPlayer() — waits 200ms, checks testPlayer → it's still the old player from the previous test → resolves immediately
3. Test proceeds — creates connector on old player, registers event listeners for SOURCE_CHANGE/PLAY/PLAYING, sets player.source
4. React finally reconciles — unmounts old TestableTHEOplayerView → native player is destroyed underneath
5. Events never fire on the now-dead player → 30s timeout → test fails