### PR TITLE
fix(conviva): bump default Conviva Core SDK on Android to 4.0.51

### DIFF
--- a/.changeset/lucky-hats-listen.md
+++ b/.changeset/lucky-hats-listen.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-conviva': patch
+---
+
+- Bumped the default Conviva Core SDK version on Android to v4.0.51.

--- a/conviva/android/build.gradle
+++ b/conviva/android/build.gradle
@@ -75,7 +75,7 @@ repositories {
 // The Conviva connector requires at least THEOplayer SDK v5.11.0.
 def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerConviva_kotlinVersion", "2.2.10")
-def conviva_version = safeExtGet('THEOplayerConviva_convivaVersion', '4.0.36')
+def conviva_version = safeExtGet('THEOplayerConviva_convivaVersion', '4.0.51')
 
 // By default, take the latest connector version, unless specified otherwise.
 def theoplayer_conviva_connector_version = safeExtGet('THEOplayerConviva_connectorVersion', '[11.0.0, 12.0.0)')


### PR DESCRIPTION
## Summary

[OPTI-3634](https://opentelly.atlassian.net/browse/OPTI-3634): the Android Conviva connector defaulted to `com.conviva.sdk:conviva-core-sdk:4.0.36`; latest is 4.0.51 (already bumped in `android-connector`), adding reporting/compat fixes for errors, ads, Media3 and background playback.

```diff
-def conviva_version = safeExtGet('THEOplayerConviva_convivaVersion', '4.0.36')
+def conviva_version = safeExtGet('THEOplayerConviva_convivaVersion', '4.0.51')
```

Consumers overriding `rootProject.ext.THEOplayerConviva_convivaVersion` are unaffected.

The ticket's second part — auditing the THEOplayer version ranges across all connectors (Android + iOS) — is intentionally left out of this PR.


Link to Devin session: https://dolby.devinenterprise.com/sessions/3060f5f4c2564cb0a496d914d9fcc58c
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->