### PR TITLE
chore: restrict supported player versions to v10 and v11

### DIFF
--- a/.changeset/quiet-lions-align.md
+++ b/.changeset/quiet-lions-align.md
@@ -1,0 +1,18 @@
+---
+'@theoplayer/react-native-analytics-adobe': minor
+'@theoplayer/react-native-analytics-adobe-edge': minor
+'@theoplayer/react-native-analytics-adscript': minor
+'@theoplayer/react-native-analytics-agama': minor
+'@theoplayer/react-native-analytics-bitmovin': minor
+'@theoplayer/react-native-analytics-comscore': minor
+'@theoplayer/react-native-analytics-conviva': minor
+'@theoplayer/react-native-drm': minor
+'@theoplayer/react-native-analytics-gemius': minor
+'@theoplayer/react-native-analytics-mux': minor
+'@theoplayer/react-native-analytics-nielsen': minor
+'@theoplayer/react-native-analytics-npaw': minor
+'@theoplayer/react-native-yospace': minor
+'@theoplayer/react-native-analytics-youbora': minor
+---
+
+- Restricted the supported OptiView (THEOplayer) player versions to v10 and v11. On Android, the default `THEOplayer_sdk` version range is now `[10.0.0, 12.0.0)` for every connector.

--- a/adobe-edge/android/build.gradle
+++ b/adobe-edge/android/build.gradle
@@ -68,8 +68,8 @@ repositories {
   maven { url "https://maven.theoplayer.com/releases" }
 }
 
-// The Adobe connector requires at least THEOplayer SDK v9.0.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[9.0.0, 12.0.0)')
+// The Adobe connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerAdobeEdge_kotlinVersion", "2.2.10")
 def gsonVersion = safeExtGet('gsonVersion', '2.13.1')
 

--- a/adobe-edge/package.json
+++ b/adobe-edge/package.json
@@ -58,8 +58,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-device-info": "^14.0.4",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/adobe/android/build.gradle
+++ b/adobe/android/build.gradle
@@ -69,8 +69,8 @@ repositories {
   maven { url "https://maven.theoplayer.com/releases" }
 }
 
-// The Adobe connector requires at least THEOplayer SDK v9.0.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[9.0.0, 12.0.0)')
+// The Adobe connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerAdobe_kotlinVersion", "2.2.10")
 def serialization_version = '1.9.0'
 

--- a/adobe/package.json
+++ b/adobe/package.json
@@ -56,8 +56,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-device-info": "^14.0.4",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/adscript/android/build.gradle
+++ b/adscript/android/build.gradle
@@ -74,8 +74,8 @@ rootProject.allprojects {
   }
 }
 
-// The AdScript connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+// The AdScript connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerAdScript_kotlinVersion", "2.2.10")
 def adscript_version = safeExtGet("THEOplayerAdScript_adscriptVersion", "1.0.10")
 

--- a/adscript/package.json
+++ b/adscript/package.json
@@ -57,8 +57,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/agama/android/build.gradle
+++ b/agama/android/build.gradle
@@ -63,7 +63,7 @@ repositories {
   maven { url "https://maven.theoplayer.com/releases" }
 }
 
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[6.0.0, 12.0.0)')
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerAgama_kotlinVersion", "2.2.10")
 
 dependencies {

--- a/agama/package.json
+++ b/agama/package.json
@@ -63,8 +63,8 @@
     "react": "*",
     "react-native": "*",
     "react-native-device-info": "^14.0.4",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/bitmovin/package.json
+++ b/bitmovin/package.json
@@ -55,8 +55,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/comscore/android/build.gradle
+++ b/comscore/android/build.gradle
@@ -69,8 +69,8 @@ repositories {
   }
 }
 
-// The Comscore connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+// The Comscore connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 
 def kotlin_version = safeExtGet("THEOplayerComscore_kotlinVersion", "2.2.10")
 def comscore_version = safeExtGet("THEOplayerComscore_comscoreVersion", "6.+")

--- a/comscore/package.json
+++ b/comscore/package.json
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/conviva/android/build.gradle
+++ b/conviva/android/build.gradle
@@ -72,8 +72,8 @@ repositories {
   maven { url "https://maven.theoplayer.com/releases" }
 }
 
-// The Conviva connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+// The Conviva connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerConviva_kotlinVersion", "2.2.10")
 def conviva_version = safeExtGet('THEOplayerConviva_convivaVersion', '4.0.51')
 

--- a/conviva/package.json
+++ b/conviva/package.json
@@ -59,8 +59,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/drm/package.json
+++ b/drm/package.json
@@ -53,8 +53,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "eslintIgnore": [
     "node_modules/",

--- a/gemius/android/build.gradle
+++ b/gemius/android/build.gradle
@@ -74,8 +74,8 @@ rootProject.allprojects {
   }
 }
 
-// The Gemius connector requires at least THEOplayer SDK v9.0.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[9.0.0, 12.0.0)')
+// The Gemius connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerGemius_kotlinVersion", "2.2.10")
 def gemius_version = safeExtGet("THEOplayerGemius_gemiusVersion", "2.0.8")
 

--- a/gemius/package.json
+++ b/gemius/package.json
@@ -56,8 +56,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/mux/package.json
+++ b/mux/package.json
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/nielsen/android/build.gradle
+++ b/nielsen/android/build.gradle
@@ -71,8 +71,8 @@ rootProject.allprojects {
   }
 }
 
-// The Nielsen connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+// The Nielsen connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerNielsen_kotlinVersion", "2.2.10")
 def nielsen_version = safeExtGet("THEOplayerNielsen_nielsenVersion", "9.2.0.0")
 

--- a/nielsen/package.json
+++ b/nielsen/package.json
@@ -58,8 +58,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/npaw/package.json
+++ b/npaw/package.json
@@ -46,8 +46,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/yospace/android/build.gradle
+++ b/yospace/android/build.gradle
@@ -78,8 +78,8 @@ repositories {
   mavenCentral()
 }
 
-// The Yospace connector requires at least THEOplayer SDK v7.6.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[7.6.0, 12.0.0)')
+// The Yospace connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerYospace_kotlinVersion", "2.2.10")
 def yospace_version = safeExtGet('yospaceVersion', '3.6.7')
 
@@ -92,7 +92,7 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.theoplayer.android-connector:yospace:$theoplayer_sdk_version"
+  implementation "com.theoplayer.android-connector:yospace:$theoplayer_yospace_connector_version"
   implementation("com.yospace:admanagement-sdk") {
     version {
       strictly("[3.6, 4.0)")

--- a/yospace/package.json
+++ b/yospace/package.json
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7.5.0 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/youbora/android/build.gradle
+++ b/youbora/android/build.gradle
@@ -72,8 +72,8 @@ rootProject.allprojects {
   }
 }
 
-// The Youbora connector requires at least THEOplayer SDK v5.11.0.
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+// The Youbora connector requires at least THEOplayer SDK v10.0.0.
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
 def kotlin_version = safeExtGet("THEOplayerYoubora_kotlinVersion", "2.2.10")
 def youbora_version = safeExtGet("THEOplayerYoubora_youboraVersion", "+")
 def youbora_config_version = safeExtGet("THEOplayerYoubora_youboraConfigVersion", "0.4.7")

--- a/youbora/package.json
+++ b/youbora/package.json
@@ -63,8 +63,8 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-    "theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+    "react-native-theoplayer": "^10 || ^11",
+    "theoplayer": "^10 || ^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {


### PR DESCRIPTION
## Summary

Follow-up on the second part of [OPTI-3634](https://opentelly.atlassian.net/browse/OPTI-3634). The declared player support was both inconsistent and unreachable: npm peers advertised `^7 || ^8 || ^9 || ^10 || ^11` while the Android floors ranged from 5.11.0 to 10.0.0 per connector, and the native connectors that actually get pulled in (Android `com.theoplayer.android-connector:*:[11.0.0, 12.0.0)`, iOS `THEOplayer-Connector-* >= 10.0`) already require player 10/11. Nothing below 11 is covered by `apps/e2e` either.

This aligns everything on v10–v11, and never loosens a range that was already stricter (so `bitmovin`/`mux` Android stay at `[10.0.0, 12.0.0)`, and the conviva/nielsen native Android connector ranges and the iOS pod dependencies are untouched).

```diff
 // package.json (all 14 connector packages)
-"react-native-theoplayer": "^7 || ^8 || ^9 || ^10 || ^11",
-"theoplayer": "^7 || ^8 || ^9 || ^10 || ^11"
+"react-native-theoplayer": "^10 || ^11",
+"theoplayer": "^10 || ^11"

 // <connector>/android/build.gradle  (5.11.0 / 6.0.0 / 7.6.0 / 9.0.0 -> 10.0.0)
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[5.11.0, 12.0.0)')
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[10.0.0, 12.0.0)')
```

Also fixes a latent bug in `yospace/android/build.gradle`, where the declared override was never used, so `ext.THEOplayerYospace_connectorVersion` was silently ignored:

```diff
-implementation "com.theoplayer.android-connector:yospace:$theoplayer_sdk_version"
+implementation "com.theoplayer.android-connector:yospace:$theoplayer_yospace_connector_version"
```

Existing consumers are unaffected: peer/pod ranges are only evaluated when installing a *newer* connector version, so apps on player 7–9 keep working on the currently released connectors, and `rootProject.ext.THEOplayer_sdk` overrides still win.

Not included (separate work): the bundled web connectors still lag player 11 — `@theoplayer/yospace-connector-web ^2.7.0` (3.0.0 adds `^11`), `@theoplayer/conviva-connector-web ^3.0.0` (3.3.1 adds `^11`), `@theoplayer/nielsen-connector-web ^1.6.0` (1.7.0 adds `^11`). Note also that conviva/nielsen keep an Android native connector floor of 11 and conviva an iOS pod floor of 10.8, so for those two the effective Android floor remains v11 despite the `^10` peer.


Link to Devin session: https://dolby.devinenterprise.com/sessions/3060f5f4c2564cb0a496d914d9fcc58c
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->