### PR TITLE
Fix adobe-edge web: "Session ID is not available" race on media events

### DIFF
--- a/.changeset/tame-donkeys-fix.md
+++ b/.changeset/tame-donkeys-fix.md
@@ -1,0 +1,6 @@
+---
+'@theoplayer/react-native-analytics-adobe-edge': patch
+---
+
+- Fixed an issue on Web where media events (e.g. `media.bitrateChange`) would fail with "Session ID is not available for playerId" when the media session start was not yet confirmed by the edge network. The session is now only marked as started after confirmation, failed session starts are retried, and tracker promise rejections no longer surface as unhandled promise rejections.
+- Fixed an issue on Web where a playback session would not be tracked at all if the player's `loadedmetadata` event fired before the Adobe media tracker was initialized.

--- a/adobe-edge/CHANGELOG.md
+++ b/adobe-edge/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @theoplayer/react-native-analytics-adobe-edge
 
-## Unreleased
-
-### 🐛 Issues
-
-- Fixed an issue on Web where media events (e.g. `media.bitrateChange`) would fail with "Session ID is not available for playerId" when the media session start was not yet confirmed by the edge network. The session is now only marked as started after confirmation, failed session starts are retried, and tracker promise rejections no longer surface as unhandled promise rejections.
-- Fixed an issue on Web where a playback session would not be tracked at all if the player's `loadedmetadata` event fired before the Adobe media tracker was initialized.
-
 ## 1.3.0
 
 ### ✨ Features

--- a/adobe-edge/CHANGELOG.md
+++ b/adobe-edge/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @theoplayer/react-native-analytics-adobe-edge
 
+## Unreleased
+
+### 🐛 Issues
+
+- Fixed an issue on Web where media events (e.g. `media.bitrateChange`) would fail with "Session ID is not available for playerId" when the media session start was not yet confirmed by the edge network. The session is now only marked as started after confirmation, failed session starts are retried, and tracker promise rejections no longer surface as unhandled promise rejections.
+- Fixed an issue on Web where a playback session would not be tracked at all if the player's `loadedmetadata` event fired before the Adobe media tracker was initialized.
+
 ## 1.3.0
 
 ### ✨ Features

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -465,9 +465,12 @@ class AdobeEdgeHandler {
     this._sessionStartAbandoned = false;
 
     // Take a snapshot of the custom metadata on the first attempt, so retries report the same metadata.
-    const customMetadata = sessionMetadata ?? this._customMetadata;
-    // Clear used custom metadata to avoid accidentally reusing it for the next session.
-    this._customMetadata = {};
+    let customMetadata = sessionMetadata;
+    if (customMetadata === undefined) {
+      customMetadata = this._customMetadata;
+      // Clear used custom metadata to avoid accidentally reusing it for the next session.
+      this._customMetadata = {};
+    }
 
     // Allow overriding metadata with custom metadata set via updateMetadata().
     const mergedMetadata = {

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -85,6 +85,9 @@ class AdobeEdgeHandler {
   /** Whether playback ended while a session start was still in flight; the confirmed session is completed before it is ended */
   private _completeOnConfirm = false;
 
+  /** Whether the handler was destroyed; no new sessions are started afterwards */
+  private _destroyed = false;
+
   /** Incremented on every session start/reset, used to invalidate in-flight starts */
   private _sessionGeneration = 0;
   private _sessionStartRetryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -140,13 +143,20 @@ class AdobeEdgeHandler {
      * Acquire Media Analytics APIs & tracker.
      * https://experienceleague.adobe.com/en/docs/experience-platform/collection/js/commands/getmediaanalyticstracker
      */
-    this._alloyClient('getMediaAnalyticsTracker', {}).then((result: any) => {
-      this._media = result;
-      this._tracker = this._media?.getInstance();
+    this._alloyClient('getMediaAnalyticsTracker', {})
+      .then((result: any) => {
+        if (this._destroyed) {
+          return;
+        }
+        this._media = result;
+        this._tracker = this._media?.getInstance();
 
-      // The player may have dispatched loadedmetadata before the tracker was ready.
-      this.maybeStartSession();
-    });
+        // The player may have dispatched loadedmetadata before the tracker was ready.
+        this.maybeStartSession();
+      })
+      .catch((error: unknown) => {
+        this.logDebug('getMediaAnalyticsTracker failed', error);
+      });
 
     this.setDebug(debugEnabled || false);
   }
@@ -431,6 +441,11 @@ class AdobeEdgeHandler {
       `isPlayingAd: ${isPlayingAd}`,
     );
 
+    if (this._destroyed) {
+      this.logDebug('maybeStartSession - NOT started: handler destroyed');
+      return;
+    }
+
     if (this._sessionInProgress || this._sessionStarting) {
       this.logDebug('maybeStartSession - NOT started: already in progress or starting');
       return;
@@ -606,6 +621,7 @@ class AdobeEdgeHandler {
   destroy() {
     this.maybeEndSession();
     this.removeEventListeners();
+    this._destroyed = true;
   }
 
   setDebug(debug: boolean) {

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -27,6 +27,16 @@ const PROP_ERROR_ID = 'errorId';
 const PROP_NA = 'NA';
 
 /**
+ * Number of times a session start is attempted before giving up.
+ */
+const MAX_SESSION_START_ATTEMPTS = 3;
+
+/**
+ * Base delay between session start attempts. Doubles with every attempt.
+ */
+const SESSION_START_RETRY_DELAY_MS = 1000;
+
+/**
  * Alloy globally stores clients by name. We are allowed create clients with the same config only once.
  */
 interface ClientDescription {
@@ -60,6 +70,13 @@ class AdobeEdgeHandler {
 
   /** Whether we are in a current session or not */
   private _sessionInProgress = false;
+
+  /** Whether a session start request is in flight (including retries) */
+  private _sessionStarting = false;
+
+  /** Incremented on every session start/reset, used to invalidate in-flight starts */
+  private _sessionGeneration = 0;
+  private _sessionStartRetryTimer: ReturnType<typeof setTimeout> | undefined;
   private _adBreakPodIndex = 0;
   private _adPodPosition = 1;
   private _customMetadata: EventMetadata = {};
@@ -115,6 +132,9 @@ class AdobeEdgeHandler {
     this._alloyClient('getMediaAnalyticsTracker', {}).then((result: any) => {
       this._media = result;
       this._tracker = this._media?.getInstance();
+
+      // The player may have dispatched loadedmetadata before the tracker was ready.
+      this.maybeStartSession();
     });
 
     this.setDebug(debugEnabled || false);
@@ -192,29 +212,35 @@ class AdobeEdgeHandler {
   }
 
   private sendEvent(eventType: EventType, info: EventInfo, metadata: EventMetadata) {
+    if (eventType === EventType.updatePlayhead) {
+      this._tracker?.updatePlayhead(info[PROP_PLAYHEAD]);
+      return;
+    }
+    let result: Promise<any> | undefined;
     switch (eventType) {
-      case EventType.updatePlayhead:
-        this._tracker?.updatePlayhead(info[PROP_PLAYHEAD]);
-        break;
       case EventType.error:
-        this._tracker?.trackError(info[PROP_ERROR_ID] || PROP_NA);
+        result = this._tracker?.trackError(info[PROP_ERROR_ID] || PROP_NA);
         break;
       case EventType.sessionComplete:
-        this._tracker?.trackComplete();
+        result = this._tracker?.trackComplete();
         break;
       case EventType.sessionEnd:
-        this._tracker?.trackSessionEnd();
+        result = this._tracker?.trackSessionEnd();
         break;
       case EventType.play:
-        this._tracker?.trackPlay();
+        result = this._tracker?.trackPlay();
         break;
       case EventType.pauseStart:
-        this._tracker?.trackPause();
+        result = this._tracker?.trackPause();
         break;
       default:
-        this._tracker?.trackEvent(eventType, info, metadata);
+        result = this._tracker?.trackEvent(eventType, info, metadata);
         break;
     }
+    // Tracker methods return promises; catch rejections to avoid unhandled promise rejections.
+    Promise.resolve(result).catch((error: unknown) => {
+      this.logDebug(`sendEvent(${eventType}) failed`, error);
+    });
   }
 
   private queueOrSendEvent(type: EventType, info: EventInfo = {}, metadata: EventMetadata = {}) {
@@ -387,8 +413,8 @@ class AdobeEdgeHandler {
       `isPlayingAd: ${isPlayingAd}`,
     );
 
-    if (this._sessionInProgress) {
-      this.logDebug('maybeStartSession - NOT started: already in progress');
+    if (this._sessionInProgress || this._sessionStarting) {
+      this.logDebug('maybeStartSession - NOT started: already in progress or starting');
       return;
     }
 
@@ -402,18 +428,43 @@ class AdobeEdgeHandler {
       return;
     }
 
+    if (!this._tracker || !this._media) {
+      // The tracker is acquired asynchronously; maybeStartSession is retried once it resolves.
+      this.logDebug('maybeStartSession - NOT started: media tracker not yet available');
+      return;
+    }
+
+    this.startSession(mediaLength, 0);
+  }
+
+  /**
+   * Start a new media session on the edge network.
+   *
+   * The session is only marked as 'in progress' once the edge network confirms it
+   * (i.e. the returned promise resolves with a sessionId). Until then, events keep
+   * queueing. If the session start fails, it is retried a limited number of times.
+   */
+  private startSession(mediaLength: number, attempt: number) {
+    const tracker = this._tracker;
+    const media = this._media;
+    if (!tracker || !media) {
+      return;
+    }
+    const generation = ++this._sessionGeneration;
+    this._sessionStarting = true;
+
     // Allow overriding metadata with custom metadata set via updateMetadata().
     const mergedMetadata = {
       ...this._player?.source?.metadata,
       ...this._customMetadata,
     };
-    this._tracker?.trackSessionStart(
-      this._media?.createMediaObject(
+    const sessionStartPromise = tracker.trackSessionStart(
+      media.createMediaObject(
         mergedMetadata.friendlyName || mergedMetadata.title || PROP_NA,
         mergedMetadata.name || mergedMetadata.id || PROP_NA,
         mediaLength,
         this.getContentType(),
-        this._media.MediaType.Video,
+        media.MediaType.Video,
       ),
       this._customMetadata,
     );
@@ -421,13 +472,57 @@ class AdobeEdgeHandler {
     // Clear used custom metadata after starting the session to avoid accidentally reusing it for the next session.
     this._customMetadata = {};
 
-    this._sessionInProgress = true;
+    Promise.resolve(sessionStartPromise)
+      .then((result?: { sessionId?: string }) => {
+        if (generation !== this._sessionGeneration) {
+          // The session was ended or superseded while the start request was in flight.
+          // Only close the confirmed session if no newer session owns the tracker.
+          if (result?.sessionId && !this._sessionStarting && !this._sessionInProgress) {
+            this.sendEvent(EventType.sessionEnd, {}, {});
+          }
+          return;
+        }
+        if (result?.sessionId) {
+          this._sessionStarting = false;
+          this._sessionInProgress = true;
 
-    // Post any queued events now that the session has started.
-    this._eventQueue.forEach((event) => this.sendEvent(event.type, event.info, event.metadata));
-    this._eventQueue = [];
+          // Post any queued events now that the session has started.
+          this._eventQueue.forEach((event) => this.sendEvent(event.type, event.info, event.metadata));
+          this._eventQueue = [];
 
-    this.logDebug('maybeStartSession - started');
+          this.logDebug('startSession - started');
+        } else {
+          this.logDebug('startSession - no sessionId in response');
+          this.retryStartSession(generation, mediaLength, attempt);
+        }
+      })
+      .catch((error: unknown) => {
+        if (generation !== this._sessionGeneration) {
+          return;
+        }
+        this.logDebug('startSession - failed', error);
+        this.retryStartSession(generation, mediaLength, attempt);
+      });
+  }
+
+  private retryStartSession(generation: number, mediaLength: number, attempt: number) {
+    if (attempt + 1 < MAX_SESSION_START_ATTEMPTS) {
+      const delay = SESSION_START_RETRY_DELAY_MS * 2 ** attempt;
+      this.logDebug(`retryStartSession - retrying in ${delay}ms (attempt ${attempt + 2}/${MAX_SESSION_START_ATTEMPTS})`);
+      this._sessionStartRetryTimer = setTimeout(() => {
+        this._sessionStartRetryTimer = undefined;
+        if (generation !== this._sessionGeneration) {
+          return;
+        }
+        this.startSession(mediaLength, attempt + 1);
+      }, delay);
+    } else {
+      // Give up: drop queued events and stay idle, so a later sourcechange or
+      // stopAndStartNewSession can start a fresh session.
+      this.logDebug('retryStartSession - giving up');
+      this._sessionStarting = false;
+      this._eventQueue = [];
+    }
   }
 
   private onLoadedMetadata = () => {
@@ -462,6 +557,13 @@ class AdobeEdgeHandler {
 
   reset() {
     this.logDebug('reset');
+    // Invalidate any in-flight session start and cancel pending retries.
+    this._sessionGeneration++;
+    this._sessionStarting = false;
+    if (this._sessionStartRetryTimer) {
+      clearTimeout(this._sessionStartRetryTimer);
+      this._sessionStartRetryTimer = undefined;
+    }
     this._eventQueue = [];
     this._adBreakPodIndex = 0;
     this._adPodPosition = 1;

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -37,6 +37,11 @@ const MAX_SESSION_START_ATTEMPTS = 3;
 const SESSION_START_RETRY_DELAY_MS = 1000;
 
 /**
+ * Maximum number of events queued while waiting for a session start to be confirmed. The oldest events are dropped first.
+ */
+const MAX_EVENT_QUEUE_SIZE = 500;
+
+/**
  * Alloy globally stores clients by name. We are allowed create clients with the same config only once.
  */
 interface ClientDescription {
@@ -254,6 +259,9 @@ class AdobeEdgeHandler {
     if (this._sessionInProgress) {
       this.sendEvent(type, extendedInfo, metadata);
     } else if (!this._sessionStartAbandoned) {
+      if (this._eventQueue.length >= MAX_EVENT_QUEUE_SIZE) {
+        this._eventQueue.shift();
+      }
       this._eventQueue.push({ type, info: extendedInfo, metadata });
     }
   }

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -74,6 +74,9 @@ class AdobeEdgeHandler {
   /** Whether a session start request is in flight (including retries) */
   private _sessionStarting = false;
 
+  /** Whether session start was abandoned after exhausting all retries; events are dropped until a new start is attempted */
+  private _sessionStartAbandoned = false;
+
   /** Incremented on every session start/reset, used to invalidate in-flight starts */
   private _sessionGeneration = 0;
   private _sessionStartRetryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -247,7 +250,7 @@ class AdobeEdgeHandler {
     const extendedInfo = { ...info, [PROP_PLAYHEAD]: sanitisePlayhead(this._player.currentTime, this._player.duration) };
     if (this._sessionInProgress) {
       this.sendEvent(type, extendedInfo, metadata);
-    } else {
+    } else if (!this._sessionStartAbandoned) {
       this._eventQueue.push({ type, info: extendedInfo, metadata });
     }
   }
@@ -452,6 +455,7 @@ class AdobeEdgeHandler {
     }
     const generation = ++this._sessionGeneration;
     this._sessionStarting = true;
+    this._sessionStartAbandoned = false;
 
     // Allow overriding metadata with custom metadata set via updateMetadata().
     const mergedMetadata = {
@@ -518,9 +522,11 @@ class AdobeEdgeHandler {
       }, delay);
     } else {
       // Give up: drop queued events and stay idle, so a later sourcechange or
-      // stopAndStartNewSession can start a fresh session.
+      // stopAndStartNewSession can start a fresh session. Until then, events are
+      // dropped instead of queued to avoid unbounded queue growth.
       this.logDebug('retryStartSession - giving up');
       this._sessionStarting = false;
+      this._sessionStartAbandoned = true;
       this._eventQueue = [];
     }
   }
@@ -560,6 +566,7 @@ class AdobeEdgeHandler {
     // Invalidate any in-flight session start and cancel pending retries.
     this._sessionGeneration++;
     this._sessionStarting = false;
+    this._sessionStartAbandoned = false;
     if (this._sessionStartRetryTimer) {
       clearTimeout(this._sessionStartRetryTimer);
       this._sessionStartRetryTimer = undefined;

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -77,6 +77,9 @@ class AdobeEdgeHandler {
   /** Whether session start was abandoned after exhausting all retries; events are dropped until a new start is attempted */
   private _sessionStartAbandoned = false;
 
+  /** Whether playback ended while a session start was still in flight; the confirmed session is completed before it is ended */
+  private _completeOnConfirm = false;
+
   /** Incremented on every session start/reset, used to invalidate in-flight starts */
   private _sessionGeneration = 0;
   private _sessionStartRetryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -287,7 +290,11 @@ class AdobeEdgeHandler {
   private handleEnded = () => {
     this.logDebug('onEnded');
     this.queueOrSendEvent(EventType.sessionComplete);
+    // The session may still be starting, in which case the queued completion is dropped by reset().
+    // Remember it so the session is completed once the edge network confirms it.
+    const completeOnConfirm = this._sessionStarting && !this._sessionInProgress;
     this.reset();
+    this._completeOnConfirm = completeOnConfirm;
   };
 
   private handleSourceChange = () => {
@@ -447,7 +454,7 @@ class AdobeEdgeHandler {
    * (i.e. the returned promise resolves with a sessionId). Until then, events keep
    * queueing. If the session start fails, it is retried a limited number of times.
    */
-  private startSession(mediaLength: number, attempt: number) {
+  private startSession(mediaLength: number, attempt: number, sessionMetadata?: EventMetadata) {
     const tracker = this._tracker;
     const media = this._media;
     if (!tracker || !media) {
@@ -457,10 +464,15 @@ class AdobeEdgeHandler {
     this._sessionStarting = true;
     this._sessionStartAbandoned = false;
 
+    // Take a snapshot of the custom metadata on the first attempt, so retries report the same metadata.
+    const customMetadata = sessionMetadata ?? this._customMetadata;
+    // Clear used custom metadata to avoid accidentally reusing it for the next session.
+    this._customMetadata = {};
+
     // Allow overriding metadata with custom metadata set via updateMetadata().
     const mergedMetadata = {
       ...this._player?.source?.metadata,
-      ...this._customMetadata,
+      ...customMetadata,
     };
     const sessionStartPromise = tracker.trackSessionStart(
       media.createMediaObject(
@@ -470,11 +482,8 @@ class AdobeEdgeHandler {
         this.getContentType(),
         media.MediaType.Video,
       ),
-      this._customMetadata,
+      customMetadata,
     );
-
-    // Clear used custom metadata after starting the session to avoid accidentally reusing it for the next session.
-    this._customMetadata = {};
 
     Promise.resolve(sessionStartPromise)
       .then((result?: { sessionId?: string }) => {
@@ -482,6 +491,10 @@ class AdobeEdgeHandler {
           // The session was ended or superseded while the start request was in flight.
           // Only close the confirmed session if no newer session owns the tracker.
           if (result?.sessionId && !this._sessionStarting && !this._sessionInProgress) {
+            if (this._completeOnConfirm) {
+              this._completeOnConfirm = false;
+              this.sendEvent(EventType.sessionComplete, {}, {});
+            }
             this.sendEvent(EventType.sessionEnd, {}, {});
           }
           return;
@@ -497,7 +510,7 @@ class AdobeEdgeHandler {
           this.logDebug('startSession - started');
         } else {
           this.logDebug('startSession - no sessionId in response');
-          this.retryStartSession(generation, mediaLength, attempt);
+          this.retryStartSession(generation, mediaLength, attempt, customMetadata);
         }
       })
       .catch((error: unknown) => {
@@ -505,11 +518,11 @@ class AdobeEdgeHandler {
           return;
         }
         this.logDebug('startSession - failed', error);
-        this.retryStartSession(generation, mediaLength, attempt);
+        this.retryStartSession(generation, mediaLength, attempt, customMetadata);
       });
   }
 
-  private retryStartSession(generation: number, mediaLength: number, attempt: number) {
+  private retryStartSession(generation: number, mediaLength: number, attempt: number, sessionMetadata: EventMetadata) {
     if (attempt + 1 < MAX_SESSION_START_ATTEMPTS) {
       const delay = SESSION_START_RETRY_DELAY_MS * 2 ** attempt;
       this.logDebug(`retryStartSession - retrying in ${delay}ms (attempt ${attempt + 2}/${MAX_SESSION_START_ATTEMPTS})`);
@@ -518,7 +531,7 @@ class AdobeEdgeHandler {
         if (generation !== this._sessionGeneration) {
           return;
         }
-        this.startSession(mediaLength, attempt + 1);
+        this.startSession(mediaLength, attempt + 1, sessionMetadata);
       }, delay);
     } else {
       // Give up: drop queued events and stay idle, so a later sourcechange or
@@ -567,6 +580,7 @@ class AdobeEdgeHandler {
     this._sessionGeneration++;
     this._sessionStarting = false;
     this._sessionStartAbandoned = false;
+    this._completeOnConfirm = false;
     if (this._sessionStartRetryTimer) {
       clearTimeout(this._sessionStartRetryTimer);
       this._sessionStartRetryTimer = undefined;

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -567,6 +567,9 @@ class AdobeEdgeHandler {
       this._sessionStarting = false;
       this._sessionStartAbandoned = true;
       this._eventQueue = [];
+      // Hand the unused metadata snapshot back, so a later session start still reports it.
+      // Metadata set in the meantime takes precedence.
+      this._customMetadata = { ...sessionMetadata, ...this._customMetadata };
     }
   }
 

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -562,13 +562,15 @@ class AdobeEdgeHandler {
     } else {
       // Give up: drop queued events and stay idle, so a later sourcechange or
       // stopAndStartNewSession can start a fresh session. Until then, events are
+    } else {
+      // Give up: drop queued events and stay idle, so a later sourcechange or
+      // stopAndStartNewSession can start a fresh session. Until then, events are
       // dropped instead of queued to avoid unbounded queue growth.
       this.logDebug('retryStartSession - giving up');
       this._sessionStarting = false;
       this._sessionStartAbandoned = true;
       this._eventQueue = [];
-      // Hand the unused metadata snapshot back, so a later session start still reports it.
-      // Metadata set in the meantime takes precedence.
+      // Restore the unused metadata snapshot so a later session start can still report it.
       this._customMetadata = { ...sessionMetadata, ...this._customMetadata };
     }
   }

--- a/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
+++ b/adobe-edge/src/internal/web/AdobeEdgeHandler.ts
@@ -562,9 +562,6 @@ class AdobeEdgeHandler {
     } else {
       // Give up: drop queued events and stay idle, so a later sourcechange or
       // stopAndStartNewSession can start a fresh session. Until then, events are
-    } else {
-      // Give up: drop queued events and stay idle, so a later sourcechange or
-      // stopAndStartNewSession can start a fresh session. Until then, events are
       // dropped instead of queued to avoid unbounded queue growth.
       this.logDebug('retryStartSession - giving up');
       this._sessionStarting = false;

--- a/adobe-edge/src/internal/web/__tests__/mocks/alloy.ts
+++ b/adobe-edge/src/internal/web/__tests__/mocks/alloy.ts
@@ -15,16 +15,17 @@ export const mockCreateQoEObject = jest.fn((bitrate: number, droppedFrames: numb
   timeToStart: startupTime,
 }));
 
-export const mockTrackEvent = jest.fn();
+export const mockTrackEvent = jest.fn((..._args: unknown[]) => Promise.resolve({}));
 export const mockUpdatePlayhead = jest.fn();
+export const mockTrackSessionStart = jest.fn(() => Promise.resolve<{ sessionId?: string }>({ sessionId: 'test-session-id' }));
 
 export const mockTracker = {
-  trackSessionStart: jest.fn(),
-  trackPlay: jest.fn(),
-  trackPause: jest.fn(),
-  trackSessionEnd: jest.fn(),
-  trackComplete: jest.fn(),
-  trackError: jest.fn(),
+  trackSessionStart: mockTrackSessionStart,
+  trackPlay: jest.fn(() => Promise.resolve({})),
+  trackPause: jest.fn(() => Promise.resolve({})),
+  trackSessionEnd: jest.fn(() => Promise.resolve({})),
+  trackComplete: jest.fn(() => Promise.resolve({})),
+  trackError: jest.fn(() => Promise.resolve({})),
   trackEvent: mockTrackEvent,
   updatePlayhead: mockUpdatePlayhead,
   updateQoEObject: jest.fn(),
@@ -67,6 +68,13 @@ export function setupAlloyMocks() {
     if (command === 'getMediaAnalyticsTracker') return Promise.resolve(mockMedia);
     return Promise.resolve();
   });
+  mockTrackSessionStart.mockResolvedValue({ sessionId: 'test-session-id' });
+  mockTrackEvent.mockResolvedValue({});
+  mockTracker.trackPlay.mockResolvedValue({});
+  mockTracker.trackPause.mockResolvedValue({});
+  mockTracker.trackSessionEnd.mockResolvedValue({});
+  mockTracker.trackComplete.mockResolvedValue({});
+  mockTracker.trackError.mockResolvedValue({});
   mockCreateQoEObject.mockImplementation((bitrate: number, droppedFrames: number, fps: number, startupTime: number) => ({
     bitrate,
     droppedFrames,

--- a/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
@@ -232,6 +232,25 @@ describe('AdobeEdgeHandler – session start', () => {
     expect(mockTracker.trackSessionEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('caps the number of events queued while the session start is in flight', async () => {
+    const start = deferred<{ sessionId?: string }>();
+    mockTrackSessionStart.mockReturnValue(start.promise);
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    for (let i = 0; i < 600; i++) {
+      emitQualityChanged(i);
+    }
+
+    start.resolve({ sessionId: 'session-5' });
+    await flushMicrotasks();
+
+    // Only the 500 most recent events are kept, the oldest ones are dropped.
+    expect(mockTrackEvent).toHaveBeenCalledTimes(500);
+    expect((mockTrackEvent.mock.calls[0][1] as any).qoeDataDetails.bitrate).toBe(100);
+  });
+
   it('closes a session that was confirmed after a sourcechange ended it', async () => {
     const start = deferred<{ sessionId?: string }>();
     mockTrackSessionStart.mockReturnValue(start.promise);

--- a/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
@@ -171,6 +171,42 @@ describe('AdobeEdgeHandler – session start', () => {
     expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
   });
 
+  it('does not start a session when the media tracker resolves after destroy', async () => {
+    const trackerDeferred = deferred<any>();
+    mockAlloyClient.mockImplementation((command: string) => {
+      if (command === 'getMediaAnalyticsTracker') return trackerDeferred.promise;
+      return Promise.resolve();
+    });
+    const handler = createHandler();
+
+    player.emit('loadedmetadata');
+    handler.destroy();
+
+    trackerDeferred.resolve(mockMedia);
+    await flushMicrotasks();
+    expect(mockTrackSessionStart).not.toHaveBeenCalled();
+  });
+
+  it('catches a rejected media tracker promise', async () => {
+    const onUnhandled = jest.fn();
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      mockAlloyClient.mockImplementation((command: string): any => {
+        if (command === 'getMediaAnalyticsTracker') return Promise.reject(new Error('tracker unavailable'));
+        return Promise.resolve();
+      });
+      createHandler();
+      await flushMicrotasks();
+
+      player.emit('loadedmetadata');
+      await flushMicrotasks();
+      expect(mockTrackSessionStart).not.toHaveBeenCalled();
+      expect(onUnhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
   it('catches tracker event rejections instead of causing unhandled rejections', async () => {
     const onUnhandled = jest.fn();
     process.on('unhandledRejection', onUnhandled);

--- a/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
@@ -194,6 +194,44 @@ describe('AdobeEdgeHandler – session start', () => {
     }
   });
 
+  it('reports the custom metadata on retried session starts', async () => {
+    jest.useFakeTimers();
+    mockTrackSessionStart.mockResolvedValueOnce({}).mockResolvedValue({ sessionId: 'session-4' });
+    const handler = createHandler();
+    handler.updateMetadata({ friendlyName: 'Custom Title', name: 'custom-name', season: '2' } as any);
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    await flushMicrotasks();
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(2);
+
+    const retryCall = mockTrackSessionStart.mock.calls[1] as unknown as unknown[];
+    expect(retryCall[1]).toEqual({ friendlyName: 'Custom Title', name: 'custom-name', season: '2' });
+    const retryMediaObject = mockMedia.createMediaObject.mock.calls[1] as unknown as unknown[];
+    expect(retryMediaObject[0]).toBe('Custom Title');
+    expect(retryMediaObject[1]).toBe('custom-name');
+  });
+
+  it('completes a session that was confirmed after playback ended', async () => {
+    const start = deferred<{ sessionId?: string }>();
+    mockTrackSessionStart.mockReturnValue(start.promise);
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+    // Playback ends before the edge network confirms the session.
+    player.emit('ended');
+
+    start.resolve({ sessionId: 'late-session' });
+    await flushMicrotasks();
+    expect(mockTracker.trackComplete).toHaveBeenCalledTimes(1);
+    expect(mockTracker.trackSessionEnd).toHaveBeenCalledTimes(1);
+  });
+
   it('closes a session that was confirmed after a sourcechange ended it', async () => {
     const start = deferred<{ sessionId?: string }>();
     mockTrackSessionStart.mockReturnValue(start.promise);

--- a/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
@@ -250,6 +250,27 @@ describe('AdobeEdgeHandler – session start', () => {
     expect(retryMediaObject[1]).toBe('custom-name');
   });
 
+  it('reports the custom metadata again after an abandoned session start', async () => {
+    jest.useFakeTimers();
+    mockTrackSessionStart.mockResolvedValue({});
+    const handler = createHandler();
+    handler.updateMetadata({ friendlyName: 'Custom Title', name: 'custom-name' } as any);
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(3);
+
+    // A new session start after giving up must still report the metadata.
+    mockTrackSessionStart.mockResolvedValue({ sessionId: 'session-6' });
+    player.emit('sourcechange');
+    player.emit('loadedmetadata');
+    await flushMicrotasks();
+
+    const newCall = mockTrackSessionStart.mock.calls[3] as unknown as unknown[];
+    expect(newCall[1]).toEqual({ friendlyName: 'Custom Title', name: 'custom-name' });
+  });
+
   it('completes a session that was confirmed after playback ended', async () => {
     const start = deferred<{ sessionId?: string }>();
     mockTrackSessionStart.mockReturnValue(start.promise);

--- a/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/sessionStart.test.ts
@@ -1,0 +1,220 @@
+// jest.mock is hoisted by babel-jest before any imports are evaluated.
+jest.mock('@adobe/alloy', () => ({
+  createInstance: jest.fn(() => mockAlloyClient),
+}));
+
+import { AdobeEdgeHandler } from '../AdobeEdgeHandler';
+import { AdobeEdgeWebConfig } from '../../../api/AdobeEdgeWebConfig';
+import { mockAlloyClient, mockMedia, mockTracker, mockTrackEvent, mockTrackSessionStart, setupAlloyMocks } from './mocks/alloy';
+import { makePlayer } from './mocks/player';
+
+// ---------------------------------------------------------------------------
+// Shared config & helpers
+// ---------------------------------------------------------------------------
+const config: AdobeEdgeWebConfig = {
+  datastreamId: 'test-datastream',
+  edgeBasePath: 'ee-pre-prd',
+  orgId: 'test-org',
+  streamingMedia: { channel: 'test', playerName: 'THEOplayer' },
+};
+
+/** Flush pending micro-tasks. Works with both real and fake timers. */
+function flushMicrotasks() {
+  return new Promise<void>((resolve) => {
+    const { port1, port2 } = new MessageChannel();
+    port1.onmessage = () => {
+      port1.close();
+      port2.close();
+      resolve();
+    };
+    port2.postMessage(null);
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Create a player mock with a valid source & duration so a session can start. */
+function makeLoadedPlayer() {
+  const { player, videoTrack, videoTracks } = makePlayer();
+  player.source = { metadata: { title: 'Test Title' } };
+  player.duration = 3600;
+  return { player, videoTrack, videoTracks };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('AdobeEdgeHandler – session start', () => {
+  let player: any;
+  let videoTrack: any;
+  let videoTracks: any;
+
+  beforeEach(() => {
+    setupAlloyMocks();
+    // noinspection JSConstantReassignment
+    global.window = { addEventListener: jest.fn(), removeEventListener: jest.fn() } as any;
+    ({ player, videoTrack, videoTracks } = makeLoadedPlayer());
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function createHandler() {
+    const handler = new AdobeEdgeHandler(player, config);
+    videoTracks.emit('addtrack', { track: videoTrack });
+    return handler;
+  }
+
+  function emitQualityChanged(bandwidth = 4_500_000) {
+    videoTrack.emit('activequalitychanged', { quality: { bandwidth, frameRate: 25 } as any });
+  }
+
+  it('queues events until the session is confirmed, then flushes them', async () => {
+    const start = deferred<{ sessionId?: string }>();
+    mockTrackSessionStart.mockReturnValue(start.promise);
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+    // Emitted while the session start is in flight: must be queued, not sent.
+    emitQualityChanged();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+
+    start.resolve({ sessionId: 'session-1' });
+    await flushMicrotasks();
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent.mock.calls[0][0]).toBe('bitrateChange');
+  });
+
+  it('retries when the session start resolves without a sessionId, then gives up', async () => {
+    jest.useFakeTimers();
+    mockTrackSessionStart.mockResolvedValue({});
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    await flushMicrotasks();
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(2);
+
+    await jest.advanceTimersByTimeAsync(2000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(3);
+
+    // No further retries after the maximum number of attempts.
+    await jest.advanceTimersByTimeAsync(10_000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(3);
+
+    // Events after a failed session start are not dispatched to the tracker.
+    emitQualityChanged();
+    await flushMicrotasks();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+
+  it('recovers when a session start retry succeeds', async () => {
+    jest.useFakeTimers();
+    mockTrackSessionStart.mockResolvedValueOnce({}).mockResolvedValue({ sessionId: 'session-2' });
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    emitQualityChanged();
+    await flushMicrotasks();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(2);
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the session start promise rejects', async () => {
+    jest.useFakeTimers();
+    mockTrackSessionStart.mockRejectedValueOnce(new Error('network error')).mockResolvedValue({ sessionId: 'session-3' });
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    await flushMicrotasks();
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1000);
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(2);
+  });
+
+  it('starts the session once the media tracker becomes available after loadedmetadata', async () => {
+    const trackerDeferred = deferred<any>();
+    mockAlloyClient.mockImplementation((command: string) => {
+      if (command === 'getMediaAnalyticsTracker') return trackerDeferred.promise;
+      return Promise.resolve();
+    });
+    createHandler();
+
+    // loadedmetadata arrives before the tracker promise resolves.
+    player.emit('loadedmetadata');
+    await flushMicrotasks();
+    expect(mockTrackSessionStart).not.toHaveBeenCalled();
+
+    trackerDeferred.resolve(mockMedia);
+    await flushMicrotasks();
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('catches tracker event rejections instead of causing unhandled rejections', async () => {
+    const onUnhandled = jest.fn();
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      createHandler();
+      await flushMicrotasks();
+
+      player.emit('loadedmetadata');
+      await flushMicrotasks();
+      expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+      // Simulate alloy rejecting events because the session is unavailable.
+      mockTrackEvent.mockRejectedValue(new Error('Session ID is not available for playerId'));
+      emitQualityChanged();
+      await flushMicrotasks();
+
+      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(onUnhandled).not.toHaveBeenCalled();
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+
+  it('closes a session that was confirmed after a sourcechange ended it', async () => {
+    const start = deferred<{ sessionId?: string }>();
+    mockTrackSessionStart.mockReturnValue(start.promise);
+    createHandler();
+    await flushMicrotasks();
+
+    player.emit('loadedmetadata');
+    expect(mockTrackSessionStart).toHaveBeenCalledTimes(1);
+
+    // Source changes while the session start is still in flight.
+    player.source = undefined;
+    player.emit('sourcechange');
+
+    // The in-flight start is confirmed afterwards: the orphaned session must be ended.
+    start.resolve({ sessionId: 'orphan-session' });
+    await flushMicrotasks();
+    expect(mockTracker.trackSessionEnd).toHaveBeenCalledTimes(1);
+
+    // A subsequent quality change must not be dispatched.
+    emitQualityChanged();
+    await flushMicrotasks();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

On web, `AdobeEdgeHandler` treated `trackSessionStart()` as fire-and-forget: it flipped `_sessionInProgress = true` immediately, so any media event fired before the edge network returned a `sessionId` was rejected by alloy with
`Failed to trigger media event: media.bitrateChange. Session ID is not available for playerId: <uuid>.`

The session is now only considered active once the start is confirmed, events are queued until then, and failed starts are retried:

```ts
startSession(mediaLength, attempt, sessionMetadata?) {
  const generation = ++this._sessionGeneration;   // invalidates in-flight starts on reset/sourcechange
  this._sessionStarting = true;
  Promise.resolve(tracker.trackSessionStart(...))
    .then((result) => {
      if (generation !== this._sessionGeneration) { /* orphan: complete if needed, then end */ return; }
      if (result?.sessionId) { this._sessionInProgress = true; flush(this._eventQueue); }
      else                   { this.retryStartSession(generation, mediaLength, attempt, customMetadata); }
    })
    .catch(() => this.retryStartSession(...));     // no more unhandled rejections
}
```

Other behaviour worth calling out:

- `maybeStartSession()` is retried once the media tracker promise resolves, so a `loadedmetadata` that arrives before the tracker is ready no longer silently skips the session start.
- Retries: 3 attempts with 1s/2s backoff. After giving up, `_sessionStartAbandoned` is set and events are dropped (not queued) until a `sourcechange`/`stopAndStartNewSession` starts a fresh session.
- The custom metadata from `updateMetadata()` is snapshotted for the first attempt and reused by every retry, so a retried session start still reports the customer's metadata instead of an empty object. Metadata set *after* the snapshot is kept for the next session.
- If playback ends while a start is still in flight, `_completeOnConfirm` remembers it so the late-confirmed session is completed (`sessionComplete`) before it is ended, instead of losing the completion.
- The pending-event queue is capped at `MAX_EVENT_QUEUE_SIZE = 500` (oldest dropped first), so a start that never resolves cannot grow the queue without bound.

## Testing

In `adobe-edge`: `npm test` (18 tests, new `sessionStart.test.ts` covers queue/flush, retry + recovery, rejection, tracker-not-ready race, metadata on retries, late completion, queue cap and orphan close), `npm run typescript`, `npm run build`.


Link to Devin session: https://dolby.devinenterprise.com/sessions/37fdbe28150a45588efc33754efcdd32
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->