### PR TITLE
Clamp Adobe Edge playhead to the accepted [0, 86400]s range

### DIFF
--- a/.changeset/tidy-pumas-cheer.md
+++ b/.changeset/tidy-pumas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@theoplayer/react-native-analytics-adobe-edge': patch
+---
+
+Fixed an issue where the Adobe VA Edge API would reject media events such as `adStart` and `adComplete` with a 400 Bad Request ("Playhead must be in range [0, 86400] seconds") during live playback on platforms that report the playhead as an absolute presentation timestamp (e.g. Samsung Tizen). The playhead is now always clamped to the range accepted by the API.

--- a/adobe-edge/android/src/main/java/com/theoplayer/reactnative/adobe/edge/Utils.kt
+++ b/adobe-edge/android/src/main/java/com/theoplayer/reactnative/adobe/edge/Utils.kt
@@ -10,6 +10,12 @@ fun sanitiseContentLength(mediaLength: Double?): Int {
   return if (mediaLength == Double.POSITIVE_INFINITY) { 86400 } else mediaLength?.toInt() ?: 0
 }
 
+/**
+ * The Adobe VA Edge API only accepts playhead values in the range [0, 86400] seconds.
+ * Values outside this range are rejected with a 400 Bad Request.
+ */
+private const val MAX_PLAYHEAD_SEC = 86400
+
 fun sanitisePlayhead(playhead: Double?, mediaLength: Double?): Int {
   if (playhead == null || mediaLength == null) {
     return 0
@@ -21,7 +27,9 @@ fun sanitisePlayhead(playhead: Double?, mediaLength: Double?): Int {
       60 * (calendar.get(Calendar.MINUTE) +
       60 * calendar.get(Calendar.HOUR_OF_DAY))
   }
-  return playhead.toInt()
+  // Clamp to the range accepted by the Adobe VA Edge API. Some platforms report the playhead of
+  // a live stream as an absolute presentation timestamp, which far exceeds the accepted range.
+  return playhead.toInt().coerceIn(0, MAX_PLAYHEAD_SEC)
 }
 
 fun isValidDuration(v: Double?): Boolean {

--- a/adobe-edge/ios/Connector/AdobeEdgeHandler.swift
+++ b/adobe-edge/ios/Connector/AdobeEdgeHandler.swift
@@ -508,11 +508,15 @@ class AdobeEdgeHandler {
         return MediaConstants.StreamType.LIVE
     }
     
+    /// The Adobe VA Edge API only accepts playhead values in the range [0, 86400] seconds.
+    /// Values outside this range are rejected with a 400 Bad Request.
+    private static let maxPlayheadSec: Double = 86400
+
     private func sanitisePlayhead(playhead: Double?, mediaLength: Double?) -> Int {
-        guard let playhead = playhead, let mediaLength = mediaLength else {
+        guard let playhead = playhead, let mediaLength = mediaLength, !playhead.isNaN else {
             return 0
         }
-        
+
         if mediaLength == Double.infinity {
             // If content is live, the playhead must be the current second of the day.
             let now = Date()
@@ -524,8 +528,10 @@ class AdobeEdgeHandler {
 
             return seconds
         }
-        
-        return Int(playhead)
+
+        // Clamp to the range accepted by the Adobe VA Edge API. Some platforms report the playhead
+        // of a live stream as an absolute presentation timestamp, which far exceeds the accepted range.
+        return Int(min(Self.maxPlayheadSec, max(0, playhead)))
     }
     
     private func sanitiseContentLength(_ mediaLength: Double?) -> Int {

--- a/adobe-edge/src/internal/web/Utils.ts
+++ b/adobe-edge/src/internal/web/Utils.ts
@@ -3,6 +3,19 @@ import type { AdobeEdgeWebConfig } from '@theoplayer/react-native-analytics-adob
 const PROP_NA = 'NA';
 
 /**
+ * The Adobe VA Edge API only accepts playhead values in the range [0, 86400] seconds.
+ * Values outside this range are rejected with a 400 Bad Request.
+ */
+const MAX_PLAYHEAD_SEC = 86400;
+
+/**
+ * Clamp a playhead value to the range accepted by the Adobe VA Edge API.
+ */
+function clampPlayhead(playheadSec: number): number {
+  return Math.min(MAX_PLAYHEAD_SEC, Math.max(0, playheadSec));
+}
+
+/**
  * Sanitise the current media length.
  *
  * - In case of a live stream, set it to 24h.
@@ -12,10 +25,13 @@ export function sanitiseContentLength(mediaLengthSec: number): number {
 }
 
 /**
- * Sanitise the current playhead in seconds. Adobe expects an integer value.
+ * Sanitise the current playhead in seconds. Adobe expects an integer value in the range [0, 86400].
  *
  * - If undefined or NaN, set it to 0.
  * - If infinite (live stream), set it to the current second of the day.
+ * - Otherwise clamp it to the range [0, 86400] accepted by the Adobe VA Edge API. Some platforms
+ *   (e.g. Samsung Tizen) report the playhead of a live stream as an absolute presentation
+ *   timestamp, which far exceeds the accepted range.
  *
  * @param playheadInSec
  * @param mediaLengthSec
@@ -27,9 +43,9 @@ export function sanitisePlayhead(playheadInSec?: number, mediaLengthSec?: number
   if (mediaLengthSec === Infinity) {
     // If content is live, the playhead must be the current second of the day.
     const date = new Date();
-    return date.getSeconds() + 60 * (date.getMinutes() + 60 * date.getHours());
+    return clampPlayhead(date.getSeconds() + 60 * (date.getMinutes() + 60 * date.getHours()));
   }
-  return Math.trunc(playheadInSec);
+  return clampPlayhead(Math.trunc(playheadInSec));
 }
 
 export function sanitiseNumber(v?: number): number {

--- a/adobe-edge/src/internal/web/__tests__/utils.test.ts
+++ b/adobe-edge/src/internal/web/__tests__/utils.test.ts
@@ -1,0 +1,42 @@
+import { sanitisePlayhead } from '../Utils';
+
+describe('sanitisePlayhead', () => {
+  it('returns 0 for undefined or NaN playhead', () => {
+    expect(sanitisePlayhead(undefined, 120)).toBe(0);
+    expect(sanitisePlayhead(NaN, 120)).toBe(0);
+  });
+
+  it('returns 0 for undefined, NaN or zero media length', () => {
+    expect(sanitisePlayhead(42, undefined)).toBe(0);
+    expect(sanitisePlayhead(42, NaN)).toBe(0);
+    expect(sanitisePlayhead(42, 0)).toBe(0);
+  });
+
+  it('truncates a normal VOD playhead', () => {
+    expect(sanitisePlayhead(42.9, 120)).toBe(42);
+  });
+
+  it('clamps a playhead exceeding the Adobe VA Edge range', () => {
+    // Samsung Tizen reports the live playhead as an absolute presentation timestamp.
+    expect(sanitisePlayhead(1754928000, 14400)).toBe(86400);
+  });
+
+  it('clamps a negative playhead', () => {
+    expect(sanitisePlayhead(-10, 120)).toBe(0);
+  });
+
+  it('keeps a playhead at the range boundaries', () => {
+    expect(sanitisePlayhead(0.5, 120)).toBe(0);
+    expect(sanitisePlayhead(86400, 86400)).toBe(86400);
+  });
+
+  it('returns the current second of the day for live content', () => {
+    const playhead = sanitisePlayhead(1754928000, Infinity);
+    const now = new Date();
+    const secondOfDay = now.getSeconds() + 60 * (now.getMinutes() + 60 * now.getHours());
+    expect(playhead).toBeGreaterThanOrEqual(0);
+    expect(playhead).toBeLessThanOrEqual(86400);
+    // Allow a few seconds of drift between the two Date() reads.
+    expect(Math.abs(playhead - secondOfDay)).toBeLessThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Problem

On Samsung Tizen CTV, live stream playhead values sent to the Adobe VA Edge API exceed the API's valid `[0, 86400]` second range, causing Adobe to reject `adStart`/`adComplete` beacon calls with a 400 error:

```json
{
  "type": "https://ns.adobe.com/aep/errors/va-edge-0400-400",
  "status": 400,
  "detail": "Invalid request. Please check your input and try again.",
  "report": { "details": "Playhead must be in range [0, 86400] seconds" }
}
```

## Root cause

`sanitisePlayhead()` only special-cases `duration === Infinity` (live → current second of the day). On Samsung Tizen, live HLS streams report a **finite** duration (DVR-window length) while `currentTime` is an **absolute/epoch-based presentation timestamp** (billions of seconds). The live branch is skipped and the raw absolute timestamp is passed through `Math.trunc()` unclamped, straight into the `playhead` field that `queueOrSendEvent` attaches to every media event on web.

## Fix

Always clamp the sanitised playhead to the `[0, 86400]` range accepted by the Adobe VA Edge API, in all platform implementations:

- `adobe-edge/src/internal/web/Utils.ts`
- `adobe-edge/android/.../Utils.kt`
- `adobe-edge/ios/Connector/AdobeEdgeHandler.swift`

Note: clamping yields a wrong-but-valid playhead for platforms with broken absolute-PTS reporting; proper normalisation needs a player-side `currentTime` fix. The clamp guarantees Adobe accepts the beacons instead of rejecting them.

## Tests

- Added `adobe-edge/src/internal/web/__tests__/utils.test.ts` covering: clamping of absolute-PTS playheads, negative playheads, normal VOD truncation, live second-of-day, NaN/undefined handling.
- Ran locally: `cd adobe-edge && npm test` (28/28 pass) and `npm run typescript` (clean). These are not covered by CI, which only runs the docs check + e2e.
- Android/iOS changes are one-line clamps verified by inspection; no unit test infrastructure exists for the native connectors.

## Notes

- Base branch is `bugfix/adobe-edge-session-start-race` as this change builds on top of that PR; rebase onto `main` once that lands.
- Includes a patch changeset for `@theoplayer/react-native-analytics-adobe-edge`.
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-connectors/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->